### PR TITLE
Correctly call listAffiliations use case

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
@@ -86,11 +86,11 @@ class DependencyManager {
     private void setupDbConnections() {
         try {
 
-            String user = Objects.requireNonNull(configurationManager.getMysqlUser())
-            String password = Objects.requireNonNull(configurationManager.getMysqlPass())
-            String host = Objects.requireNonNull(configurationManager.getMysqlHost())
-            String port = Objects.requireNonNull(configurationManager.getMysqlPort())
-            String sqlDatabase = Objects.requireNonNull(configurationManager.getMysqlDB())
+            String user = Objects.requireNonNull(configurationManager.getMysqlUser(), "Mysql user missing.")
+            String password = Objects.requireNonNull(configurationManager.getMysqlPass(), "Mysql password missing.")
+            String host = Objects.requireNonNull(configurationManager.getMysqlHost(), "Mysql host missing.")
+            String port = Objects.requireNonNull(configurationManager.getMysqlPort(), "Mysql port missing.")
+            String sqlDatabase = Objects.requireNonNull(configurationManager.getMysqlDB(), "Mysql database name missing.")
 
             DatabaseSession.create(user, password, host, port, sqlDatabase)
             CustomerDatabaseQueries queries = new CustomerDatabaseQueries(DatabaseSession.INSTANCE)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/DependencyManager.groovy
@@ -86,11 +86,11 @@ class DependencyManager {
     private void setupDbConnections() {
         try {
 
-            String user = configurationManager.getMysqlUser()
-            String password = configurationManager.getMysqlPass()
-            String host = configurationManager.getMysqlHost()
-            String port = configurationManager.getMysqlPort()
-            String sqlDatabase = configurationManager.getMysqlDB()
+            String user = Objects.requireNonNull(configurationManager.getMysqlUser())
+            String password = Objects.requireNonNull(configurationManager.getMysqlPass())
+            String host = Objects.requireNonNull(configurationManager.getMysqlHost())
+            String port = Objects.requireNonNull(configurationManager.getMysqlPort())
+            String sqlDatabase = Objects.requireNonNull(configurationManager.getMysqlDB())
 
             DatabaseSession.create(user, password, host, port, sqlDatabase)
             CustomerDatabaseQueries queries = new CustomerDatabaseQueries(DatabaseSession.INSTANCE)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/controllers/ListAffiliationsController.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/controllers/ListAffiliationsController.groovy
@@ -1,0 +1,24 @@
+package life.qbic.portal.qoffer2.web.controllers
+
+import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.portal.portlet.customers.affiliation.list.ListAffiliationsInput
+
+/**
+ * This class serves as adapter for the ListAffiliations use case
+ *
+ * As a user, I want to list all affiliations available to me.
+ *
+ * @since: 1.0.0
+ */
+class ListAffiliationsController {
+
+    private final ListAffiliationsInput useCase
+
+    ListAffiliationsController(ListAffiliationsInput useCase) {
+        this.useCase = useCase
+    }
+
+    void listAffiliations()  {
+        useCase.listAffiliations()
+    }
+}

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/ListAffiliationsPresenter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/ListAffiliationsPresenter.groovy
@@ -5,11 +5,9 @@ import life.qbic.portal.portlet.customers.affiliation.list.ListAffiliationsOutpu
 import life.qbic.portal.qoffer2.web.viewmodel.ViewModel
 
 /**
- * <short description>
+ * This class acts as a presenter for the ListAffiliation use case. It takes care of reflecting the updated information in the view model
  *
- * <detailed description>
- *
- * @since: <versiontag>
+ * @since: 1.0.0
  */
 class ListAffiliationsPresenter implements ListAffiliationsOutput{
 

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/ListAffiliationsPresenter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/ListAffiliationsPresenter.groovy
@@ -1,0 +1,27 @@
+package life.qbic.portal.qoffer2.web.presenters
+
+import life.qbic.datamodel.dtos.business.Affiliation
+import life.qbic.portal.portlet.customers.affiliation.list.ListAffiliationsOutput
+import life.qbic.portal.qoffer2.web.viewmodel.ViewModel
+
+/**
+ * <short description>
+ *
+ * <detailed description>
+ *
+ * @since: <versiontag>
+ */
+class ListAffiliationsPresenter implements ListAffiliationsOutput{
+
+    private final ViewModel viewModel
+
+    ListAffiliationsPresenter(ViewModel viewModel) {
+        this.viewModel = viewModel
+    }
+
+    @Override
+    void reportAvailableAffiliations(List<Affiliation> affiliations) {
+        viewModel.affiliations.clear()
+        viewModel.affiliations.addAll(affiliations)
+    }
+}


### PR DESCRIPTION
**PR Checklist**

- [x] This comment contains a description of changes (with reason)

## Description of changes
This PR does not change behaviour visible to users but rather ensures that the database interaction in retrieving a list of available affiliations is performed over a use case.

## Technical details
The ListAffiliations use case is now integrated into the portlet creation. After successful CreateCustomerView initialization, the list affiliations use case is triggered and fills the available affiliations with data.

