### PR TITLE
Hotfix/groovydocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 			<name>QBiC Releases</name>
 			<url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-releases</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 	<dependencyManagement>
 		<dependencies>
@@ -64,4 +68,11 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<distributionManagement>
+		<site>
+			<id>dummytest</id>
+			<url>localhost:8080</url>
+		</site>
+	</distributionManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,6 @@
 			<name>QBiC Releases</name>
 			<url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-releases</url>
 		</repository>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
 	</repositories>
 	<dependencyManagement>
 		<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 			<name>QBiC Releases</name>
 			<url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-releases</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 	<dependencyManagement>
 		<dependencies>

--- a/qoffer-infrastructure/pom.xml
+++ b/qoffer-infrastructure/pom.xml
@@ -40,5 +40,11 @@
             <artifactId>commons-dbcp2</artifactId>
             <version>2.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
+
 </project>


### PR DESCRIPTION
Many thanks for contributing to this project! 

**Technical details**
This hotfixes aims to resolve 3 issues:
1.) Allow for proper linkage between the maven modules in the project report by enabling the site:stage command, which is dependent on an explicit setting of the `distribution managment` setting in the parent pom. 
The actual settings of the distribution management properties are irrelevant apparently --> MAVEN MAGICKS 

2.) Resolve the missing dependency of the` everit json schema` package induced by the inclusion of the `data-model-lib` dependency in the `qoffer-infrastructure `module by providing the` jitpack repository` explicitly.

3.) Resolve the `classpath invocation error`, which was the result of trying to access a javax.servlet dependency outside of the provided classpaths. I provided the javax servlet dependency explictily in the `qoffer-infrastructure` pom which resolved this issue. 

To check if the reports on the site are properly generated run the `mvn site site:stage` command and check the` index.html `in the `target/staging` folder of the parent `qOffer_2.0` module 