### PR TITLE
Refactor eMailAddress field access to emailAddress

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDatabaseQueries.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDatabaseQueries.groovy
@@ -60,13 +60,7 @@ class CustomerDatabaseQueries {
                 String firstName = "${rs.getString(2)}"
                 String emailAddress = "${rs.getString(5)}";
                 AcademicTitle academicTitle = academicTitleFactory.getForString("${rs.getString(4)}")
-                def customer = new Customer(
-                    firstName,
-                    lastName,
-                    academicTitle,
-                    emailAddress,
-                    affiliations
-                )
+                Customer customer = new Customer.Builder(firstName, lastName, emailAddress).title(academicTitle).affiliations(affiliations).build()
                 result.add(customer)
             }
         }
@@ -251,7 +245,7 @@ class CustomerDatabaseQueries {
         statement.setString(1, customer.firstName )
         statement.setString(2, customer.lastName)
         statement.setString(3, customer.title.value)
-        statement.setString(4, customer.eMailAddress )
+        statement.setString(4, customer.emailAddress)
         statement.execute()
         def keys = statement.getGeneratedKeys()
         while (keys.next()){

--- a/qoffer-infrastructure/src/test/groovy/life/qbic/portal/qoffer2/database/SearchCustomerDataSourceSpec.groovy
+++ b/qoffer-infrastructure/src/test/groovy/life/qbic/portal/qoffer2/database/SearchCustomerDataSourceSpec.groovy
@@ -30,7 +30,7 @@ class SearchCustomerDataSourceSpec extends Specification{
         and: "a connection returning correct results only for matching firstname and lastname"
         // we need to stub the static SqlExtensions.toRowResult method because we do not provide an implemented RowResult
         GroovyMock(SqlExtensions, global: true)
-        SqlExtensions.toRowResult(_ as ResultSet) >> new GroovyRowResult(["id":id, "firstName":firstName, "lastName":lastName, "academicTitle":academicTitle, "eMailAddress":emailAddress])
+        SqlExtensions.toRowResult(_ as ResultSet) >> new GroovyRowResult(["id":id, "firstName":firstName, "lastName":lastName, "academicTitle":academicTitle, "emailAddress":emailAddress])
         // our statement should only be able to fill the template with the correct values
         PreparedStatement preparedStatement = Mock (PreparedStatement, {
             it.setString(1 , firstName) >> _
@@ -57,7 +57,7 @@ class SearchCustomerDataSourceSpec extends Specification{
         customer.firstName == firstName
         customer.lastName == lastName
         customer.title == factory.getForString(academicTitle)
-        customer.eMailAddress == emailAddress
+        customer.emailAddress == emailAddress
         //TODO also test for affiliations
 
 

--- a/qoffer-infrastructure/src/test/groovy/life/qbic/portal/qoffer2/web/controllers/CreateCustomerControllerSpec.groovy
+++ b/qoffer-infrastructure/src/test/groovy/life/qbic/portal/qoffer2/web/controllers/CreateCustomerControllerSpec.groovy
@@ -34,7 +34,7 @@ class CreateCustomerControllerSpec extends Specification {
             customer.firstName == firstName && \
             customer.lastName == lastName && \
             customer.title == academicTitle && \
-            customer.eMailAddress == email && \
+            customer.emailAddress == email && \
             customer.affiliations == affiliations
         })
         where:


### PR DESCRIPTION
**Purpose of this PR**
This PR adapts the refactor of the "eMailAddress" field to "emailAddress" of the Customer DTO to all methods and tests of TOMATO accessing the field.   
**Misc**  
See this PR For details on the refactoring: 
https://github.com/qbicsoftware/data-model-lib/pull/96