### PR TITLE
Refactor Create Customer Use Case to use new DTO and correct fieldNames.

### DIFF
--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/offers/create/CreateOffer.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/offers/create/CreateOffer.groovy
@@ -1,6 +1,6 @@
 package life.qbic.portal.portlet.offers.create
 
-import life.qbic.datamodel.accounting.ProductItem
+import life.qbic.datamodel.dtos.business.ProductItem
 import life.qbic.datamodel.dtos.business.AffiliationCategory
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.datamodel.dtos.business.OfferId

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/customers/CustomerDbConnector.groovy
@@ -217,7 +217,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
       def statement = connection.prepareStatement(query)
       statement.setString(1, customer.firstName)
       statement.setString(2, customer.lastName)
-      statement.setString(3, customer.eMailAddress)
+      statement.setString(3, customer.emailAddress)
       statement.execute()
       def result = statement.getResultSet()
       customerAlreadyInDb = result.next()
@@ -235,7 +235,7 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
     statement.setString(1, customer.firstName )
     statement.setString(2, customer.lastName)
     statement.setString(3, customer.title.value)
-    statement.setString(4, customer.eMailAddress )
+    statement.setString(4, customer.emailAddress )
     statement.execute()
     def keys = statement.getGeneratedKeys()
     while (keys.next()){
@@ -253,8 +253,8 @@ class CustomerDbConnector implements CreateCustomerDataSource, UpdateCustomerDat
     affiliations.each {affiliation ->
       def affiliationId = getAffiliationId(connection, affiliation)
       def statement = connection.prepareStatement(query)
-      statement.setInt(1, affiliationId)
-      statement.setInt(2, customerId)
+      statement.setInt(1, customerId)
+      statement.setInt(2, affiliationId)
       statement.execute()
 
     }


### PR DESCRIPTION
**Description of changes**
This PR introduces the new DTO `ProductItem` in the `Create Offer` use case and takes into account the naming change of the `emailaddress` field of the `Customer` DTO in the `Create Customer` use case 

