### PR TITLE
Fix #234 (naming of affiliation field)

### DIFF
--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
@@ -54,7 +54,7 @@ class CreateAffiliationView extends VerticalLayout {
         this.organisationBox = new ComboBox<>("Organisation Name")
         
         // we don't need the whole affiliation object, just the unique organization names.
-        List<String> organisationNames = sharedViewModel.affiliations.stream().map(it.organisation).distinct().collect(Collectors.toList())
+        List<String> organisationNames = sharedViewModel.affiliations.stream().map(affiliation -> affiliation.organisation).distinct().collect(Collectors.toList())
 
         organisationBox.setItems(organisationNames)
         organisationBox.setTextInputAllowed(true)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
@@ -51,21 +51,21 @@ class CreateAffiliationView extends VerticalLayout {
 
     private void initLayout() {
         this.organisationField = new TextField("Organisation Name")
-        organisationField.setPlaceholder("name of the organisation")
+        organisationField.setPlaceholder("Name of the organisation")
         organisationField.setDescription("Please enter the name of the organisation e.g. Universität Tübingen.")
 
-        this.addressAdditionField = new TextField("Department")
-        addressAdditionField.setPlaceholder("optional department name")
+        this.addressAdditionField = new TextField("Address Addition")
+        addressAdditionField.setPlaceholder("Department, Faculty, or other specification of affiliation name")
         addressAdditionField.setDescription("In case the affiliation differs from the organisation you can further specify that here.")
 
         this.streetField = new TextField("Street")
-        streetField.setPlaceholder("street name and street number ")
+        streetField.setPlaceholder("Street name and street number ")
         this.postalCodeField = new TextField("Postal Code")
-        postalCodeField.setPlaceholder("customer postal code")
+        postalCodeField.setPlaceholder("Customer postal code")
         this.cityField = new TextField("City")
-        cityField.setPlaceholder("name of the city")
+        cityField.setPlaceholder("Name of the city")
         this.countryField = new TextField("Country")
-        countryField.setPlaceholder("name of the country")
+        countryField.setPlaceholder("Name of the country")
         this.affiliationCategoryField = generateAffiliationCategorySelect(createAffiliationViewModel.affiliationCategories)
 
         this.abortButton = new Button("Abort Affiliation Creation")
@@ -326,7 +326,7 @@ class CreateAffiliationView extends VerticalLayout {
         ComboBox comboBox = new ComboBox<>("Affiliation Category")
         comboBox.setItems(possibleCategories)
         comboBox.setEmptySelectionAllowed(false)
-        comboBox.setPlaceholder("the affiliation category")
+        comboBox.setPlaceholder("The affiliation category")
         comboBox.setDescription("""We define three major business affiliation categories here
         - internal: 
             An affiliation we consider as within the University of Tübingen or University Hospital of Tübingen

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateAffiliationView.groovy
@@ -54,7 +54,7 @@ class CreateAffiliationView extends VerticalLayout {
         this.organisationBox = new ComboBox<>("Organisation Name")
         
         // we don't need the whole affiliation object, just the unique organization names.
-        List<String> organisationNames = sharedViewModel.affiliations.stream().map(affi -> affi.organisation).distinct().collect(Collectors.toList())
+        List<String> organisationNames = sharedViewModel.affiliations.stream().map(it.organisation).distinct().collect(Collectors.toList())
 
         organisationBox.setItems(organisationNames)
         organisationBox.setTextInputAllowed(true)

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/views/CreateCustomerView.groovy
@@ -62,15 +62,15 @@ class CreateCustomerView extends VerticalLayout {
         this.titleField = generateTitleSelector(createCustomerViewModel.academicTitles)
 
         this.firstNameField = new TextField("First Name")
-        firstNameField.setPlaceholder("customer first name")
+        firstNameField.setPlaceholder("Customer first name")
         firstNameField.setRequiredIndicatorVisible(true)
 
         this.lastNameField = new TextField("Last Name")
-        lastNameField.setPlaceholder("customer last name")
+        lastNameField.setPlaceholder("Customer last name")
         lastNameField.setRequiredIndicatorVisible(true)
 
         this.emailField = new TextField("Email Address")
-        emailField.setPlaceholder("customer email address")
+        emailField.setPlaceholder("Customer email address")
         emailField.setRequiredIndicatorVisible(true)
 
         this.affiliationComboBox = generateAffiliationSelector(sharedViewModel.affiliations)
@@ -284,7 +284,7 @@ class CreateCustomerView extends VerticalLayout {
     private static ComboBox<Affiliation> generateAffiliationSelector(List<Affiliation> affiliationList) {
         ComboBox<Affiliation> affiliationComboBox =
                 new ComboBox<>("Affiliation")
-        affiliationComboBox.setPlaceholder("select customer affiliation")
+        affiliationComboBox.setPlaceholder("Select customer affiliation")
         affiliationComboBox.setItems(affiliationList)
         affiliationComboBox.setEmptySelectionAllowed(false)
         affiliationComboBox.setItemCaptionGenerator({it.organisation})
@@ -298,7 +298,7 @@ class CreateCustomerView extends VerticalLayout {
     private static ComboBox<String> generateTitleSelector(List<String> academicTitles) {
         ComboBox<String> titleCombobox =
                 new ComboBox<>("Academic Title")
-        titleCombobox.setPlaceholder("select academic title")
+        titleCombobox.setPlaceholder("Select academic title")
         titleCombobox.setItems(academicTitles)
         titleCombobox.setEmptySelectionAllowed(true)
         return titleCombobox


### PR DESCRIPTION
- Change "department" to "address addition" to comply with labeling in other view
- Make description more informative
- Capitalize descriptions in "create customer" and "create affiliation" tabs
- Use editable dropdown for "create affiliation" organisation name to allow user to re-use existing names