### PR TITLE
Add successNotification method to create affiliation 

### DIFF
--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliation.groovy
@@ -34,7 +34,6 @@ class CreateAffiliation implements CreateAffiliationInput{
     void createAffiliation(Affiliation affiliation) {
         try {
             dataSource.addAffiliation(affiliation)
-            output.successNotification("Successfully added new affiliation " + affiliation.organisation)
             output.affiliationCreated(affiliation)
 
             log.info("Successfully added new affiliation " + affiliation.organisation)

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationOutput.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationOutput.groovy
@@ -16,4 +16,10 @@ interface CreateAffiliationOutput extends UseCaseFailure {
      * @since 1.0.0
      */
     void affiliationCreated(Affiliation affiliation)
+
+    /**
+     * This method informs the output that it shall provide a success notification for the user
+     * @param message
+     */
+    void successNotification(String message)
 }

--- a/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationOutput.groovy
+++ b/qoffer-domain/src/main/groovy/life/qbic/portal/portlet/customers/affiliation/create/CreateAffiliationOutput.groovy
@@ -16,10 +16,4 @@ interface CreateAffiliationOutput extends UseCaseFailure {
      * @since 1.0.0
      */
     void affiliationCreated(Affiliation affiliation)
-
-    /**
-     * This method informs the output that it shall provide a success notification for the user
-     * @param message
-     */
-    void successNotification(String message)
 }

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
@@ -45,6 +45,7 @@ class CreateAffiliationPresenter implements CreateAffiliationOutput {
         this.createAffiliationViewModel.affiliationCategoryValid = null
     }
 
+    @Override
     void successNotification(String notification) {
         sharedViewModel.successNotifications.add(notification)
         clearAffiliationData()

--- a/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
+++ b/qoffer-infrastructure/src/main/groovy/life/qbic/portal/qoffer2/web/presenters/CreateAffiliationPresenter.groovy
@@ -46,21 +46,15 @@ class CreateAffiliationPresenter implements CreateAffiliationOutput {
     }
 
     @Override
-    void successNotification(String notification) {
-        sharedViewModel.successNotifications.add(notification)
-        clearAffiliationData()
-    }
-
-    @Override
     void failNotification(String notification) {
         sharedViewModel.failureNotifications.add(notification)
     }
 
-    /**
-     * @inheritDoc
-     */
+
     @Override
     void affiliationCreated(Affiliation affiliation) {
         createAffiliationViewModel.affiliationService.reloadResources()
+        sharedViewModel.successNotifications.add("Successfully added new affiliation " + affiliation.organisation)
+        clearAffiliationData()
     }
 }


### PR DESCRIPTION
**Purpose**
The method `successNotification` was missing in the interface but still used, this might cause problems at some point since the actual method implemented in the present was shown as unused although in use.

**Changes**
Add the method to the output interface of the create affiliation use case