### PR TITLE
Include productId in product accession in database connector and tests

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -2,6 +2,7 @@ package life.qbic.portal.offermanager.dataresources.products
 
 import groovy.sql.GroovyRowResult
 import groovy.util.logging.Log4j2
+import life.qbic.datamodel.dtos.business.OfferId
 import life.qbic.datamodel.dtos.business.ProductItem
 import life.qbic.datamodel.dtos.business.services.*
 import life.qbic.business.exceptions.DatabaseQueryException
@@ -77,37 +78,38 @@ class ProductsDbConnector {
 
   private static Product rowResultToProduct(GroovyRowResult row) {
     def productCategory = row.category
+    String productId = row.productId
     Product product
     switch(productCategory) {
       case "Data Storage":
         product = new DataStorage(row.productName as String,
             row.description as String,
             row.unitPrice as Double,
-            new ProductUnitFactory().getForString(row.unit as String))
+            new ProductUnitFactory().getForString(row.unit as String), parseProductId(productId))
         break
       case "Primary Bioinformatics":
         product = new PrimaryAnalysis(row.productName as String,
             row.description as String,
             row.unitPrice as Double,
-            new ProductUnitFactory().getForString(row.unit as String))
+            new ProductUnitFactory().getForString(row.unit as String), parseProductId(productId))
         break
       case "Project Management":
         product = new ProjectManagement(row.productName as String,
             row.description as String,
             row.unitPrice as Double,
-            new ProductUnitFactory().getForString(row.unit as String))
+            new ProductUnitFactory().getForString(row.unit as String), parseProductId(productId))
         break
       case "Secondary Bioinformatics":
         product = new SecondaryAnalysis(row.productName as String,
             row.description as String,
             row.unitPrice as Double,
-            new ProductUnitFactory().getForString(row.unit as String))
+            new ProductUnitFactory().getForString(row.unit as String), parseProductId(productId))
         break
       case "Sequencing":
         product = new Sequencing(row.productName as String,
             row.description as String,
             row.unitPrice as Double,
-            new ProductUnitFactory().getForString(row.unit as String))
+            new ProductUnitFactory().getForString(row.unit as String), parseProductId(productId))
         break
     }
     if(product == null) {
@@ -167,6 +169,12 @@ class ProductsDbConnector {
     return foundId[0]
   }
 
+  static String parseProductId(String productId) {
+    def splitId = productId.split("_")
+    // The first entry [0] contains the product type which is assigned automatically, no need to parse it.
+    String identifier = splitId[1]
+    return identifier
+  }
 
 
   /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -169,6 +169,12 @@ class ProductsDbConnector {
     return foundId[0]
   }
 
+  /**
+   * Returns the product identifying running number given a productId
+   *
+   * @param productId String of productId stored in the DB e.g. "DS_1"
+   * @return identifier String of the iterative identifying part of the productId
+   */
   static String parseProductId(String productId) {
     def splitId = productId.split("_")
     // The first entry [0] contains the product type which is assigned automatically, no need to parse it.

--- a/offer-manager-app/src/test/groovy/life/qbic/portal/qoffer2/products/ProductsDbConnectorSpec.groovy
+++ b/offer-manager-app/src/test/groovy/life/qbic/portal/qoffer2/products/ProductsDbConnectorSpec.groovy
@@ -54,7 +54,7 @@ class ProductsDbConnectorSpec extends Specification {
     GroovyMock(SqlExtensions, global: true)
     SqlExtensions.toRowResult(_ as ResultSet) >> new GroovyRowResult(
         ["id":id, "category":category, "description":description, "productName": productName,
-         "unitPrice": unitPrice, "unit": unit])
+         "unitPrice": unitPrice, "unit": unit, "productId": productId])
     ResultSet resultSet = Stub(ResultSet, {
       it.next() >>> [true, false]
     })
@@ -76,9 +76,8 @@ class ProductsDbConnectorSpec extends Specification {
     result.get(0).description == "Sample QC with report"
 
     where: "available products information is as follows"
-    id | category | description | productName | unitPrice | unit
-    0 | "Primary Bioinformatics" | "Sample QC with report" | "Sample QC" | 49.99 | "Sample"
-
+    id | category | description | productName | unitPrice | unit | productId
+    0 | "Primary Bioinformatics" | "Sample QC with report" | "Sample QC" | 49.99 | "Sample" | "DS_1"
   }
 
   def "Returns correct id for a given product"() {
@@ -111,14 +110,14 @@ class ProductsDbConnectorSpec extends Specification {
     ProductsDbConnector dataSource = new ProductsDbConnector(connectionProvider)
 
     when:
-    int resultId = dataSource.findProductId(new PrimaryAnalysis(productName,description,unitPrice, unit))
+    int resultId = dataSource.findProductId(new PrimaryAnalysis(productName,description,unitPrice, unit, identifier))
 
     then:
     resultId == id
 
     where: "available products information is as follows"
-    id | category | description | productName | unitPrice | unit
-    0 | "Primary Bioinformatics" | "Sample QC with report" | "Sample QC" | 49.99 | ProductUnit.PER_SAMPLE
+    id | category | description | productName | unitPrice | unit | identifier
+    0 | "Primary Bioinformatics" | "Sample QC with report" | "Sample QC" | 49.99 | ProductUnit.PER_SAMPLE | "1"
 
   }
 }

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -52,9 +52,9 @@ class OfferSpec extends Specification {
         given: "A list of product items"
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE)),
+                        " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET))
+                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
         ]
 
         and: "an internal offer containing these product items"
@@ -77,9 +77,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                " example", 1.0, ProductUnit.PER_SAMPLE)),
+                " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-               "Just an example", 10.0, ProductUnit.PER_DATASET))
+               "Just an example", 10.0, ProductUnit.PER_DATASET, "!"))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -107,9 +107,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE)),
+                        " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET))
+                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -137,9 +137,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET)),
+                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1")),
                 new ProductItem(1, new DataStorage("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_GIGABYTE))
+                        "Just an example", 10.0, ProductUnit.PER_GIGABYTE, "1"))
 
         ]
 

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -79,7 +79,7 @@ class OfferSpec extends Specification {
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
                 " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-               "Just an example", 10.0, ProductUnit.PER_DATASET, "!"))
+               "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
@@ -27,8 +27,8 @@ class CreateOfferSpec extends Specification {
         CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)
 
         and:
-        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE)),
-                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE))]
+        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE, "1")),
+                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE, "1"))]
         when:
         createOffer.calculatePrice(items, new Affiliation.Builder("Test", "", "", "").category
         (AffiliationCategory.INTERNAL).build())


### PR DESCRIPTION
**Description of changes**
This fix is intended to adapt the q-offer-manager product to adapt to the inclusion of the productId in the individual products. 
See PR [here](https://github.com/qbicsoftware/data-model-lib/pull/146).
