### PR TITLE
Specify Locale.US for offer-date in OfferPdf

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -183,7 +183,7 @@ class OfferToPDFConverter implements OfferExporter {
     }
 
     void setQuotationDetails() {
-        DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.LONG)
+        DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.LONG, Locale.US)
 
         htmlContent.getElementById("offer-identifier").text(offer.identifier.toString())
         htmlContent.getElementById("offer-expiry-date").text(offer.expirationDate.toLocalDate().toString())


### PR DESCRIPTION
**Description of changes**
Fixes #260 by setting the Locale.US of the offer date explicitly in the Offer PDF 