### PR TITLE
Implement Fetch Offer Infrastructure 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Introduce Offer retrieval via Fetch Offer Use Case
+
 **Fixed**
 
 * Update the agreement section of the offer (`#329 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/329>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager
 
 import groovy.util.logging.Log4j2
+import life.qbic.business.offers.fetch.FetchOffer
 import life.qbic.datamodel.dtos.business.AcademicTitle
 import life.qbic.datamodel.dtos.business.AffiliationCategory
 import life.qbic.business.customers.affiliation.create.CreateAffiliation
@@ -9,6 +10,8 @@ import life.qbic.business.offers.create.CreateOffer
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.datamodel.dtos.general.Person
 import life.qbic.portal.offermanager.communication.EventEmitter
+import life.qbic.portal.offermanager.components.offer.overview.OfferOverviewController
+import life.qbic.portal.offermanager.components.offer.overview.OfferOverviewPresenter
 import life.qbic.portal.offermanager.components.person.search.SearchPersonView
 import life.qbic.portal.offermanager.components.person.search.SearchPersonViewModel
 import life.qbic.portal.offermanager.components.person.update.UpdatePersonViewModel
@@ -79,6 +82,7 @@ class DependencyManager {
     private CreateAffiliationPresenter createAffiliationPresenter
     private CreateOfferPresenter createOfferPresenter
     private CreateOfferPresenter updateOfferPresenter
+    private OfferOverviewPresenter offerOverviewPresenter
 
     private CustomerDbConnector customerDbConnector
     private OfferDbConnector offerDbConnector
@@ -90,6 +94,7 @@ class DependencyManager {
     private CreateAffiliation createAffiliation
     private CreateOffer createOffer
     private CreateOffer updateOffer
+    private FetchOffer fetchOffer
 
     private CreatePersonController createCustomerController
     private CreatePersonController updateCustomerController
@@ -97,6 +102,7 @@ class DependencyManager {
     private CreateAffiliationController createAffiliationController
     private CreateOfferController createOfferController
     private CreateOfferController updateOfferController
+    private OfferOverviewController offerOverviewController
 
     private CreatePersonView createCustomerView
     private CreatePersonView updatePersonView
@@ -257,8 +263,7 @@ class DependencyManager {
         }
 
         try {
-            this.offerOverviewModel = new OfferOverviewModel(overviewService, offerDbConnector,
-                    viewModel, offerUpdateEvent)
+            this.offerOverviewModel = new OfferOverviewModel(overviewService, viewModel, offerUpdateEvent)
         } catch (Exception e) {
             log.error("Unexpected excpetion during ${OfferOverviewModel.getSimpleName()} view model setup.", e)
         }
@@ -319,6 +324,11 @@ class DependencyManager {
         } catch (Exception e) {
             log.error("Unexpected exception during ${CreateOfferViewModel.getSimpleName()} setup", e)
         }
+        try {
+            this.offerOverviewPresenter = new OfferOverviewPresenter(this.viewModel, this.offerOverviewModel)
+        } catch (Exception e) {
+            log.error("Unexpected exception during ${OfferOverviewPresenter.getSimpleName()} setup", e)
+        }
     }
 
     private void setupUseCaseInteractors() {
@@ -328,6 +338,7 @@ class DependencyManager {
         this.createOffer = new CreateOffer(offerDbConnector, createOfferPresenter)
         this.updateOffer = new CreateOffer(offerDbConnector, updateOfferPresenter)
         this.updateCustomer = new CreateCustomer(updateCustomerPresenter, customerDbConnector)
+        this.fetchOffer = new FetchOffer(offerDbConnector, offerOverviewPresenter)
     }
 
     private void setupControllers() {
@@ -364,6 +375,11 @@ class DependencyManager {
             this.updateOfferController = new CreateOfferController(this.updateOffer,this.updateOffer)
         } catch (Exception e) {
             log.error("Unexpected exception during ${CreateOfferController.getSimpleName()} setup", e)
+        }
+        try {
+            this.offerOverviewController = new OfferOverviewController(this.fetchOffer)
+        } catch (Exception e) {
+            log.error("Unexpected exception during ${OfferOverviewController.getSimpleName()} setup", e)
         }
     }
 
@@ -427,7 +443,7 @@ class DependencyManager {
 
         OfferOverviewView overviewView
         try {
-            overviewView = new OfferOverviewView(offerOverviewModel)
+            overviewView = new OfferOverviewView(offerOverviewModel, offerOverviewController)
         } catch (Exception e) {
             log.error("Could not create ${OfferOverviewView.getSimpleName()} view.", e)
             throw e

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
@@ -96,6 +96,7 @@ class DependencyManager {
     private CreateOffer updateOffer
     private FetchOffer fetchOfferOfferOverview
     private FetchOffer fetchOfferCreateOffer
+    private FetchOffer fetchOfferUpdateOffer
 
     private CreatePersonController createCustomerController
     private CreatePersonController updateCustomerController
@@ -341,6 +342,7 @@ class DependencyManager {
         this.updateCustomer = new CreateCustomer(updateCustomerPresenter, customerDbConnector)
         this.fetchOfferOfferOverview = new FetchOffer(offerDbConnector, offerOverviewPresenter)
         this.fetchOfferCreateOffer = new FetchOffer(offerDbConnector, createOfferPresenter)
+        this.fetchOfferUpdateOffer = new FetchOffer(offerDbConnector, updateOfferPresenter)
     }
 
     private void setupControllers() {
@@ -374,7 +376,7 @@ class DependencyManager {
             log.error("Unexpected exception during ${CreateOfferController.getSimpleName()} setup", e)
         }
         try {
-            this.updateOfferController = new CreateOfferController(this.updateOffer, this.fetchOfferOfferOverview, this.updateOffer)
+            this.updateOfferController = new CreateOfferController(this.updateOffer, this.fetchOfferUpdateOffer, this.updateOffer)
         } catch (Exception e) {
             log.error("Unexpected exception during ${CreateOfferController.getSimpleName()} setup", e)
         }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
@@ -94,7 +94,8 @@ class DependencyManager {
     private CreateAffiliation createAffiliation
     private CreateOffer createOffer
     private CreateOffer updateOffer
-    private FetchOffer fetchOffer
+    private FetchOffer fetchOfferOfferOverview
+    private FetchOffer fetchOfferCreateOffer
 
     private CreatePersonController createCustomerController
     private CreatePersonController updateCustomerController
@@ -338,7 +339,8 @@ class DependencyManager {
         this.createOffer = new CreateOffer(offerDbConnector, createOfferPresenter)
         this.updateOffer = new CreateOffer(offerDbConnector, updateOfferPresenter)
         this.updateCustomer = new CreateCustomer(updateCustomerPresenter, customerDbConnector)
-        this.fetchOffer = new FetchOffer(offerDbConnector, offerOverviewPresenter)
+        this.fetchOfferOfferOverview = new FetchOffer(offerDbConnector, offerOverviewPresenter)
+        this.fetchOfferCreateOffer = new FetchOffer(offerDbConnector, createOfferPresenter)
     }
 
     private void setupControllers() {
@@ -367,17 +369,17 @@ class DependencyManager {
             throw e
         }
         try {
-            this.createOfferController = new CreateOfferController(this.createOffer,this.createOffer)
+            this.createOfferController = new CreateOfferController(this.createOffer, this.fetchOfferCreateOffer, this.createOffer)
         } catch (Exception e) {
             log.error("Unexpected exception during ${CreateOfferController.getSimpleName()} setup", e)
         }
         try {
-            this.updateOfferController = new CreateOfferController(this.updateOffer,this.updateOffer)
+            this.updateOfferController = new CreateOfferController(this.updateOffer, this.fetchOfferOfferOverview, this.updateOffer)
         } catch (Exception e) {
             log.error("Unexpected exception during ${CreateOfferController.getSimpleName()} setup", e)
         }
         try {
-            this.offerOverviewController = new OfferOverviewController(this.fetchOffer)
+            this.offerOverviewController = new OfferOverviewController(this.fetchOfferOfferOverview)
         } catch (Exception e) {
             log.error("Unexpected exception during ${OfferOverviewController.getSimpleName()} setup", e)
         }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
@@ -81,7 +81,7 @@ class CreateOfferController {
         }
     }
     /**
-     * This method calls the Fetch Offer use case with the provided OfferId
+     * Triggers the FetchOffer use case on execution
      *
      * @param offerId The OfferId of the Offer to be retrieved
      */

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
@@ -77,4 +77,5 @@ class CreateOfferController {
             throw new IllegalArgumentException("Could not calculate price from provided arguments.")
         }
     }
+
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager.components.offer.create
 
 import groovy.util.logging.Log4j2
+import life.qbic.business.offers.fetch.FetchOfferInput
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.Offer
@@ -24,10 +25,12 @@ class CreateOfferController {
 
     private final CreateOfferInput input
     private final CalculatePrice calculatePrice
+    private final FetchOfferInput fetchOfferInput
 
-    CreateOfferController(CreateOfferInput input, CalculatePrice calculatePrice){
+    CreateOfferController(CreateOfferInput input, FetchOfferInput fetchOfferInput ,CalculatePrice calculatePrice){
         this.input = input
         this.calculatePrice = calculatePrice
+        this.fetchOfferInput = fetchOfferInput
     }
 
     /**
@@ -76,6 +79,14 @@ class CreateOfferController {
             log.error(ignored.stackTrace.join("\n"))
             throw new IllegalArgumentException("Could not calculate price from provided arguments.")
         }
+    }
+    /**
+     * This method calls the Fetch Offer use case with the provided OfferId
+     *
+     * @param offerId The OfferId of the Offer to be retrieved
+     */
+    void fetchOffer(OfferId offerId) {
+        this.fetchOfferInput.fetchOffer(offerId)
     }
 
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
@@ -83,7 +83,7 @@ class CreateOfferController {
     /**
      * Triggers the FetchOffer use case on execution
      *
-     * @param offerId The OfferId of the Offer to be retrieved
+     * @param offerId The identifier of the offer to be fetched
      */
     void fetchOffer(OfferId offerId) {
         this.fetchOfferInput.fetchOffer(offerId)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferPresenter.groovy
@@ -4,7 +4,7 @@ import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.business.offers.create.CreateOfferOutput
 import life.qbic.portal.offermanager.dataresources.offers.OfferResourcesService
 import life.qbic.portal.offermanager.components.AppViewModel
-
+import life.qbic.business.offers.fetch.FetchOfferOutput
 /**
  * AppPresenter for the CreateOffer
  *
@@ -12,7 +12,7 @@ import life.qbic.portal.offermanager.components.AppViewModel
  *
  * @since: 1.0.0
  */
-class CreateOfferPresenter implements CreateOfferOutput {
+class CreateOfferPresenter implements CreateOfferOutput, FetchOfferOutput{
 
     private final AppViewModel viewModel
     private final CreateOfferViewModel createOfferViewModel
@@ -29,6 +29,7 @@ class CreateOfferPresenter implements CreateOfferOutput {
     void createdNewOffer(Offer createdOffer) {
         this.viewModel.successNotifications.add("Created offer with title " +
                 "\'${createdOffer.projectTitle}\' successfully")
+
         this.offerService.addToResource(createdOffer)
     }
 
@@ -50,4 +51,8 @@ class CreateOfferPresenter implements CreateOfferOutput {
        this.viewModel.failureNotifications.add(notification)
     }
 
+    @Override
+    void fetchedOffer(Offer fetchedOffer) {
+        this.createOfferViewModel.savedOffer = Optional.ofNullable(fetchedOffer)
+    }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferPresenter.groovy
@@ -53,6 +53,6 @@ class CreateOfferPresenter implements CreateOfferOutput, FetchOfferOutput{
 
     @Override
     void fetchedOffer(Offer fetchedOffer) {
-        this.createOfferViewModel.savedOffer = Optional.ofNullable(fetchedOffer)
+        this.createOfferViewModel.savedOffer = Optional.of(fetchedOffer)
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferView.groovy
@@ -56,7 +56,7 @@ class CreateOfferView extends FormLayout{
 
         this.projectManagerSelectionView = new ProjectManagerSelectionView(viewModel)
         this.selectItemsView = new SelectItemsView(viewModel,sharedViewModel)
-        this.overviewView = new OfferOverviewView(viewModel, offerProviderService)
+        this.overviewView = new OfferOverviewView(viewModel, controller, offerProviderService)
 
         initLayout()
         registerListeners()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
@@ -50,7 +50,7 @@ class CreateOfferViewModel {
     @Bindable double overheads = 0
     @Bindable double totalPrice = 0
 
-    Optional<Offer> savedOffer
+    Optional<Offer> savedOffer = Optional.empty()
 
     private final CustomerResourceService customerService
     private final ProductsResourcesService productsResourcesService

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
@@ -3,6 +3,7 @@ package life.qbic.portal.offermanager.components.offer.create
 import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
+import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.datamodel.dtos.business.OfferId
 import life.qbic.datamodel.dtos.business.ProjectManager
 import life.qbic.datamodel.dtos.business.services.*
@@ -47,8 +48,9 @@ class CreateOfferViewModel {
     @Bindable double netPrice = 0
     @Bindable double taxes = 0
     @Bindable double overheads = 0
-    @Bindable
-    double totalPrice = 0
+    @Bindable double totalPrice = 0
+
+    Optional<Offer> savedOffer
 
     private final CustomerResourceService customerService
     private final ProductsResourcesService productsResourcesService

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -204,9 +204,10 @@ class OfferOverviewView extends VerticalLayout{
         First, we make sure that no download resources are still attached to the download
         button.
          */
-        //Check if an Offer has been saved.
         removeExistingResources()
+        //Check if an Offer has been saved.
         if (!createOfferViewModel.savedOffer.isPresent()) {
+            downloadOffer.setEnabled(false)
             return
         }
         // Then we create a new PDF resource ...

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -54,13 +54,13 @@ class OfferOverviewView extends VerticalLayout{
         initLayout()
         setUpGrid()
         service.subscribe((Offer offer) -> {
-                try {
-                    createOfferController.fetchOffer(offer.identifier)
-                    addOfferResource(offer)
+            try {
+                createOfferController.fetchOffer(offer.identifier)
+                addOfferResource(offer)
                 } catch (Exception e) {
-                    log.error("Unable to create the offer PDF resource.")
-                    log.error(e.message)
-                    log.error(e.stackTrace.join("\n"))
+                log.error("Unable to create the offer PDF resource.")
+                log.error(e.message)
+                log.error(e.stackTrace.join("\n"))
                 }
         })
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -57,11 +57,11 @@ class OfferOverviewView extends VerticalLayout{
             try {
                 createOfferController.fetchOffer(offer.identifier)
                 addOfferResource(offer)
-                } catch (Exception e) {
+            } catch (Exception e) {
                 log.error("Unable to create the offer PDF resource.")
                 log.error(e.message)
                 log.error(e.stackTrace.join("\n"))
-                }
+            }
         })
     }
 
@@ -219,7 +219,7 @@ class OfferOverviewView extends VerticalLayout{
         currentFileDownloader.extend(downloadOffer)
         downloadOffer.setEnabled(true)
         }
-    }
+
 
     private void removeExistingResources() {
         if (currentFileDownloader) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -54,14 +54,14 @@ class OfferOverviewView extends VerticalLayout{
         initLayout()
         setUpGrid()
         service.subscribe((Offer offer) -> {
-            try {
-                createOfferController.fetchOffer(offer.identifier)
-                addOfferResource(createOfferViewModel.savedOffer.get())
-            } catch (Exception e) {
-                log.error("Unable to create the offer PDF resource.")
-                log.error(e.message)
-                log.error(e.stackTrace.join("\n"))
-            }
+                try {
+                    createOfferController.fetchOffer(offer.identifier)
+                    addOfferResource(offer)
+                } catch (Exception e) {
+                    log.error("Unable to create the offer PDF resource.")
+                    log.error(e.message)
+                    log.error(e.stackTrace.join("\n"))
+                }
         })
     }
 
@@ -204,17 +204,19 @@ class OfferOverviewView extends VerticalLayout{
         First, we make sure that no download resources are still attached to the download
         button.
          */
-        removeExistingResources()
-        // Then we create a new PDF resource ...
-
-        OfferToPDFConverter converter = new OfferToPDFConverter(offer)
-        StreamResource offerResource = new StreamResource((StreamResource.StreamSource res) -> {
-                    return converter.getOfferAsPdf()
-                }, "${offer.identifier.toString()}.pdf")
-        // ... and attach it to the download button
-        currentFileDownloader = new FileDownloader(offerResource)
-        currentFileDownloader.extend(downloadOffer)
-        downloadOffer.setEnabled(true)
+        //Check if an Offer has been saved.
+        if (createOfferViewModel.savedOffer) {
+            removeExistingResources()
+            // Then we create a new PDF resource ...
+            OfferToPDFConverter converter = new OfferToPDFConverter(createOfferViewModel.savedOffer.get())
+            StreamResource offerResource = new StreamResource((StreamResource.StreamSource res) -> {
+                return converter.getOfferAsPdf()
+            }, "${offer.identifier.toString()}.pdf")
+            // ... and attach it to the download button
+            currentFileDownloader = new FileDownloader(offerResource)
+            currentFileDownloader.extend(downloadOffer)
+            downloadOffer.setEnabled(true)
+        }
     }
 
     private void removeExistingResources() {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -205,17 +205,19 @@ class OfferOverviewView extends VerticalLayout{
         button.
          */
         //Check if an Offer has been saved.
-        if (createOfferViewModel.savedOffer) {
-            removeExistingResources()
-            // Then we create a new PDF resource ...
-            OfferToPDFConverter converter = new OfferToPDFConverter(createOfferViewModel.savedOffer.get())
-            StreamResource offerResource = new StreamResource((StreamResource.StreamSource res) -> {
-                return converter.getOfferAsPdf()
-            }, "${offer.identifier.toString()}.pdf")
-            // ... and attach it to the download button
-            currentFileDownloader = new FileDownloader(offerResource)
-            currentFileDownloader.extend(downloadOffer)
-            downloadOffer.setEnabled(true)
+        removeExistingResources()
+        if (!createOfferViewModel.savedOffer.isPresent()) {
+            return
+        }
+        // Then we create a new PDF resource ...
+        OfferToPDFConverter converter = new OfferToPDFConverter(createOfferViewModel.savedOffer.get())
+        StreamResource offerResource = new StreamResource((StreamResource.StreamSource res) -> {
+            return converter.getOfferAsPdf()
+        }, "${offer.identifier.toString()}.pdf")
+        // ... and attach it to the download button
+        currentFileDownloader = new FileDownloader(offerResource)
+        currentFileDownloader.extend(downloadOffer)
+        downloadOffer.setEnabled(true)
         }
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -46,15 +46,17 @@ class OfferOverviewView extends VerticalLayout{
     Button previous
     Button save
     Button downloadOffer
+    CreateOfferController createOfferController
 
-
-    OfferOverviewView(CreateOfferViewModel viewModel, OfferResourcesService service){
+    OfferOverviewView(CreateOfferViewModel viewModel, CreateOfferController controller, OfferResourcesService service){
         this.createOfferViewModel = viewModel
+        this.createOfferController = controller
         initLayout()
         setUpGrid()
         service.subscribe((Offer offer) -> {
             try {
-                addOfferResource(offer)
+                createOfferController.fetchOffer(offer.identifier)
+                addOfferResource(createOfferViewModel.savedOffer.get())
             } catch (Exception e) {
                 log.error("Unable to create the offer PDF resource.")
                 log.error(e.message)
@@ -204,6 +206,7 @@ class OfferOverviewView extends VerticalLayout{
          */
         removeExistingResources()
         // Then we create a new PDF resource ...
+
         OfferToPDFConverter converter = new OfferToPDFConverter(offer)
         StreamResource offerResource = new StreamResource((StreamResource.StreamSource res) -> {
                     return converter.getOfferAsPdf()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewController.groovy
@@ -1,0 +1,32 @@
+package life.qbic.portal.offermanager.components.offer.overview
+
+import groovy.util.logging.Log4j2
+import life.qbic.business.offers.fetch.FetchOfferInput
+import life.qbic.datamodel.dtos.business.OfferId
+
+/**
+ * Controller class adapter from view information into use case input interface
+ *
+ * This class translates the information that was received from the OfferOverView into method calls to the use case
+ *
+ * @since: 1.0.0
+ *
+ */
+@Log4j2
+class OfferOverviewController {
+
+    private final FetchOfferInput input
+
+    OfferOverviewController(FetchOfferInput input){
+        this.input = input
+    }
+
+    /**
+     * This method calls the Fetch Offer use case with the provided OfferId
+     *
+     * @param offerId The OfferId of the Offer to be retrieved
+     */
+    void fetchOffer(OfferId offerId){
+        this.input.fetchOffer(offerId)
+    }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewModel.groovy
@@ -4,7 +4,6 @@ import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.portal.offermanager.communication.EventEmitter
 import life.qbic.portal.offermanager.components.AppViewModel
-import life.qbic.portal.offermanager.dataresources.offers.OfferDbConnector
 import life.qbic.portal.offermanager.OfferToPDFConverter
 import life.qbic.portal.offermanager.dataresources.offers.OverviewService
 import life.qbic.portal.offermanager.dataresources.offers.OfferOverview
@@ -32,11 +31,9 @@ class OfferOverviewModel {
      */
     Optional<OfferOverview> selectedOffer
 
-    private Optional<Offer> offer
+    Optional<Offer> offer
 
     private final OverviewService service
-
-    private final OfferDbConnector connector
 
     private final AppViewModel viewModel
 
@@ -47,11 +44,9 @@ class OfferOverviewModel {
     EventEmitter offerEventEmitter
 
     OfferOverviewModel(OverviewService service,
-                       OfferDbConnector connector,
                        AppViewModel viewModel,
                        EventEmitter<Offer> offerEventEmitter) {
         this.service = service
-        this.connector = connector
         this.offerOverviewList = new ObservableList(new ArrayList(service.iterator().toList()))
         this.selectedOffer = Optional.empty()
         this.viewModel = viewModel
@@ -69,15 +64,8 @@ class OfferOverviewModel {
         })
     }
 
-    void setSelectedOffer(OfferOverview selectedOffer) {
-        this.selectedOffer = Optional.ofNullable(selectedOffer)
-        this.downloadButtonActive = false
-        if (this.selectedOffer.isPresent()) {
-            this.offer = loadOfferInfo()
-        }
-    }
-
     Offer getSelectedOffer() {
+        this.downloadButtonActive = false
         if(offer.isPresent()) {
             return offer.get()
         } else {
@@ -98,10 +86,4 @@ class OfferOverviewModel {
                 "convert.")})
     }
 
-    private Optional<Offer> loadOfferInfo() {
-        Optional<Offer> offer = selectedOffer
-                .map({ connector.getOffer(it.offerId) })
-                .orElse(Optional.empty())
-        return offer
-    }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewPresenter.groovy
@@ -1,0 +1,35 @@
+package life.qbic.portal.offermanager.components.offer.overview
+
+import life.qbic.business.offers.fetch.FetchOfferOutput
+import life.qbic.datamodel.dtos.business.Offer
+import life.qbic.portal.offermanager.components.AppViewModel
+
+
+/**
+ * AppPresenter for the FetchOffer Use Case
+ *
+ * This presenter handles the output of the FetchOffer use case and prepares it for a view.
+ *
+ * @since: 1.0.0
+ */
+class OfferOverviewPresenter implements FetchOfferOutput {
+
+    private final AppViewModel viewModel
+    private final OfferOverviewModel offerOverviewModel
+
+    OfferOverviewPresenter(AppViewModel viewModel, OfferOverviewModel offerOverviewModel){
+        this.viewModel = viewModel
+        this.offerOverviewModel = offerOverviewModel
+    }
+
+    @Override
+    void fetchedOffer(Offer fetchedOffer) {
+        this.offerOverviewModel.offer = Optional.ofNullable(fetchedOffer)
+    }
+
+    @Override
+    void failNotification(String notification) {
+        this.viewModel.failureNotifications.add(notification)
+    }
+
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -38,6 +38,8 @@ class OfferOverviewView extends FormLayout {
 
     final private OfferOverviewModel model
 
+    final private OfferOverviewController offerOverviewController
+
     final private Grid<OfferOverview> overviewGrid
 
     final private Button downloadBtn
@@ -49,8 +51,9 @@ class OfferOverviewView extends FormLayout {
     private FileDownloader fileDownloader
 
 
-    OfferOverviewView(OfferOverviewModel model) {
+    OfferOverviewView(OfferOverviewModel model, OfferOverviewController offerOverviewController) {
         this.model = model
+        this.offerOverviewController = offerOverviewController
         this.overviewGrid = new Grid<>()
         this.downloadBtn = new Button(VaadinIcons.DOWNLOAD)
         this.updateOfferBtn = new Button(VaadinIcons.EDIT)
@@ -155,6 +158,7 @@ class OfferOverviewView extends FormLayout {
 
     private void createResourceForDownload() {
         removeExistingResources()
+
         StreamResource offerResource =
                 new StreamResource((StreamResource.StreamSource res) -> {
                     return model.getOfferAsPdf()
@@ -188,17 +192,16 @@ class OfferOverviewView extends FormLayout {
                 downloadBtn.setEnabled(false)
                 updateOfferBtn.setEnabled(false)
             })
+                offerOverviewController.fetchOffer(offerOverview.offerId)
+                createResourceForDownload()
 
-            model.setSelectedOffer(offerOverview)
-            createResourceForDownload()
-
-            ui.access(() -> {
-                downloadSpinner.setVisible(false)
-                overviewGrid.setEnabled(true)
-                downloadBtn.setEnabled(true)
-                updateOfferBtn.setEnabled(true)
-                ui.setPollInterval(-1)
-            })
+                ui.access(() -> {
+                    downloadSpinner.setVisible(false)
+                    overviewGrid.setEnabled(true)
+                    downloadBtn.setEnabled(true)
+                    updateOfferBtn.setEnabled(true)
+                    ui.setPollInterval(-1)
+                })
         }
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -52,5 +52,6 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
         super.productItems.clear()
         super.productItems.addAll(offer.items.collect {
             new ProductItemViewModel(it.quantity, it.product)})
+        super.savedOffer = Optional.of(offer)
     }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
@@ -41,7 +41,7 @@ class FetchOffer implements FetchOfferInput {
         }
         catch (DatabaseQueryException queryException) {
             log.error(queryException.message)
-            output.failNotification("Could not retrieve Offer with OfferId " + offerId.toString() + " from the Database")
+            output.failNotification("Could not retrieve Offer with OfferId ${offerId.toString()} from the Database")
         }
         catch (Exception e) {
             log.error(e.message)

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
@@ -32,21 +32,21 @@ class FetchOffer implements FetchOfferInput {
         try {
             Optional<Offer> foundOffer = dataSource.getOffer(offerId)
             if (foundOffer.isEmpty()) {
-                output.failNotification("Could not find an Offer for the given OfferId $offerId")
+                output.failNotification("Could not find an Offer for the given OfferId " + offerId.toString())
             } else {
                 Offer finalOffer = generateOfferFromSource(foundOffer.get())
-                log.info("Successfully retrieved Offer with Id $offerId")
+                log.info("Successfully retrieved Offer with Id" + offerId.toString())
                 output.fetchedOffer(finalOffer)
             }
         }
         catch (DatabaseQueryException queryException) {
             log.error(queryException.message)
-            output.failNotification("Could not retrieve Offer with OfferId $offerId from the Database")
+            output.failNotification("Could not retrieve Offer with OfferId " + offerId.toString() + " from the Database")
         }
         catch (Exception e) {
             log.error(e.message)
             log.error(e.stackTrace.join("\n"))
-            output.failNotification("Unexpected error when searching for the Offer associated with the Id $offerId")
+            output.failNotification("Unexpected error when searching for the Offer associated with the Id " + offerId.toString())
         }
     }
     private static Offer generateOfferFromSource(Offer offer){

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
@@ -32,10 +32,10 @@ class FetchOffer implements FetchOfferInput {
         try {
             Optional<Offer> foundOffer = dataSource.getOffer(offerId)
             if (foundOffer.isEmpty()) {
-                output.failNotification("Could not find an Offer for the given OfferId " + offerId.toString())
+                output.failNotification("Could not find an Offer for the given OfferId ${offerId.toString()}")
             } else {
                 Offer finalOffer = generateOfferFromSource(foundOffer.get())
-                log.info("Successfully retrieved Offer with Id" + offerId.toString())
+                log.info("Successfully retrieved Offer with Id ${offerId.toString()} ")
                 output.fetchedOffer(finalOffer)
             }
         }
@@ -46,7 +46,7 @@ class FetchOffer implements FetchOfferInput {
         catch (Exception e) {
             log.error(e.message)
             log.error(e.stackTrace.join("\n"))
-            output.failNotification("Unexpected error when searching for the Offer associated with the Id " + offerId.toString())
+            output.failNotification("Unexpected error when searching for the Offer associated with the Id ${offerId.toString()}")
         }
     }
     private static Offer generateOfferFromSource(Offer offer){

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/fetch/FetchOffer.groovy
@@ -31,7 +31,7 @@ class FetchOffer implements FetchOfferInput {
     void fetchOffer(OfferId offerId) {
         try {
             Optional<Offer> foundOffer = dataSource.getOffer(offerId)
-            if (foundOffer.isEmpty()) {
+            if (!foundOffer.isPresent()) {
                 output.failNotification("Could not find an Offer for the given OfferId ${offerId.toString()}")
             } else {
                 Offer finalOffer = generateOfferFromSource(foundOffer.get())

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/fetch/FetchOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/fetch/FetchOfferSpec.groovy
@@ -87,7 +87,7 @@ class FetchOfferSpec extends Specification {
         FetchOfferDataSource ds = Stub(FetchOfferDataSource.class)
         FetchOffer fetchOffer = new FetchOffer(ds, output)
 
-        ds.getOffer(offerId) >> { throw new DatabaseQueryException("Could not retrieve Offer with OfferId $offerId from the Database") }
+        ds.getOffer(offerId) >> { throw new DatabaseQueryException("Could not retrieve Offer with OfferId ${offerId.toString()} from the Database") }
 
         when:
         fetchOffer.fetchOffer(offerId)


### PR DESCRIPTION
**Description of changes**
This PR connects the previously introduced Fetch Offer Use Case(See this [PR](https://github.com/qbicsoftware/offer-manager-2-portlet/pull/344)) to the Create Offer and OfferOverview Components.
This is necessary since both components allow the independent download of the generated Offer which should include additional information not stored in the database.
