### PR TITLE
Add product maintenance interfaces

### DIFF
--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductDataSource.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductDataSource.groovy
@@ -1,0 +1,36 @@
+package life.qbic.business.products
+
+import life.qbic.business.exceptions.DatabaseQueryException
+import life.qbic.datamodel.dtos.business.ProductId
+import life.qbic.datamodel.dtos.business.services.Product
+
+/**
+ * Defines the methods of the Datasource implementation
+ *
+ * @since: 1.0.0
+ *
+ */
+interface ProductDataSource {
+
+    /**
+     * Fetches a product from the database
+     * @param productId The product id of the product to be fetched
+     * @return returns an optional that contains the product if it has been found
+     * @throws DatabaseQueryException
+     */
+    Optional<Product> fetch(ProductId productId) throws DatabaseQueryException
+
+    /**
+     * Stores a product in the database
+     * @param product The product that needs to be stored
+     * @throws DatabaseQueryException
+     */
+    void store(Product product) throws DatabaseQueryException
+
+    /**
+     * A product is archived by setting it inactive
+     * @param product The product that needs to be archived
+     * @throws DatabaseQueryException
+     */
+    void archive(Product product) throws DatabaseQueryException
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductDataSource.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductDataSource.groovy
@@ -16,6 +16,7 @@ interface ProductDataSource {
      * Fetches a product from the database
      * @param productId The product id of the product to be fetched
      * @return returns an optional that contains the product if it has been found
+     * @since 1.0.0
      * @throws DatabaseQueryException
      */
     Optional<Product> fetch(ProductId productId) throws DatabaseQueryException
@@ -23,6 +24,7 @@ interface ProductDataSource {
     /**
      * Stores a product in the database
      * @param product The product that needs to be stored
+     * @since 1.0.0
      * @throws DatabaseQueryException
      */
     void store(Product product) throws DatabaseQueryException
@@ -30,6 +32,7 @@ interface ProductDataSource {
     /**
      * A product is archived by setting it inactive
      * @param product The product that needs to be archived
+     * @since 1.0.0
      * @throws DatabaseQueryException
      */
     void archive(Product product) throws DatabaseQueryException

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -1,0 +1,12 @@
+package life.qbic.business.products.archive
+
+/**
+ * <class short description - One Line!>
+ *
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since: <versiontag>
+ *
+ */
+class ArchiveProduct {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -1,11 +1,12 @@
 package life.qbic.business.products.archive
 
 /**
- * <class short description - One Line!>
+ * <h1>4.3.1 Archive Service Product</h1>
+ * <br>
+ * <p> The use case archives unused or old service products. These products cannot be added to new offers but still show in old offers.</p>
+ * <br>
  *
- * <More detailed description - When to use, what it solves, etc.>
- *
- * @since: <versiontag>
+ * @since: 1.0.0
  *
  */
 class ArchiveProduct {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -3,10 +3,10 @@ package life.qbic.business.products.archive
 import life.qbic.datamodel.dtos.business.ProductId
 
 /**
- * <h1>4.3.2 Copy Service Product</h1>
+ * <h1>4.3.2 Archive Service Product</h1>
  * <br>
- * <p> Offer Administrators are allowed to create a new permutation of an existing product.
- * <br> New permutations can include changes in unit price, sequencing technology and other attributes of service products.
+ * <p> Offer Administrators are allowed to archive existing products.
+ * <br> The archived products should be still available in old offers but not selectable for new offers.
  * </p>
  *
  * @since: 1.0.0

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.products.archive
 
+import life.qbic.datamodel.dtos.business.ProductId
+
 /**
  * <h1>4.3.1 Archive Service Product</h1>
  * <br>
@@ -10,4 +12,8 @@ package life.qbic.business.products.archive
  *
  */
 class ArchiveProduct implements ArchiveProductInput {
+    @Override
+    void archive(ProductId productId) {
+
+    }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -3,10 +3,11 @@ package life.qbic.business.products.archive
 import life.qbic.datamodel.dtos.business.ProductId
 
 /**
- * <h1>4.3.1 Archive Service Product</h1>
+ * <h1>4.3.2 Copy Service Product</h1>
  * <br>
- * <p> The use case archives unused or old service products. These products cannot be added to new offers but still show in old offers.</p>
- * <br>
+ * <p> Offer Administrators are allowed to create a new permutation of an existing product.
+ * <br> New permutations can include changes in unit price, sequencing technology and other attributes of service products.
+ * </p>
  *
  * @since: 1.0.0
  *

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProduct.groovy
@@ -9,5 +9,5 @@ package life.qbic.business.products.archive
  * @since: 1.0.0
  *
  */
-class ArchiveProduct {
+class ArchiveProduct implements ArchiveProductInput {
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.products.archive
 
+import life.qbic.datamodel.dtos.business.ProductId
+
 /**
  * Input interface for the {@link ArchiveProduct} use case
  *
@@ -7,5 +9,11 @@ package life.qbic.business.products.archive
  *
  */
 interface ArchiveProductInput {
+
+    /**
+     * A product defined by its product id should be archived
+     * @param productId The product id for the product that needs to be archived
+     */
+    void archive(ProductId productId)
 
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
@@ -12,7 +12,8 @@ interface ArchiveProductInput {
 
     /**
      * A product defined by its product id should be archived
-     * @param productId The product id for the product that needs to be archived
+     * @param productId the product id for the product that will be archived
+     * @since 1.0.0
      */
     void archive(ProductId productId)
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductInput.groovy
@@ -1,0 +1,11 @@
+package life.qbic.business.products.archive
+
+/**
+ * Input interface for the {@link ArchiveProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+interface ArchiveProductInput {
+
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
@@ -1,0 +1,10 @@
+package life.qbic.business.products.archive
+
+/**
+ * Output interface for the {@link ArchiveProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+class ArchiveProductOutput {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
@@ -14,6 +14,7 @@ interface ArchiveProductOutput extends UseCaseFailure{
     /**
      * A product has been archived in the database
      * @param product The product that has been archived
+     * @since 1.0.0
      */
     void archived(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
@@ -1,10 +1,19 @@
 package life.qbic.business.products.archive
 
+import life.qbic.business.UseCaseFailure
+import life.qbic.datamodel.dtos.business.services.Product
+
 /**
  * Output interface for the {@link ArchiveProduct} use case
  *
  * @since: 1.0.0
  *
  */
-class ArchiveProductOutput {
+interface ArchiveProductOutput extends UseCaseFailure{
+
+    /**
+     * A product has been archived in the database
+     * @param product The product that has been archived
+     */
+    void archived(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/archive/ArchiveProductOutput.groovy
@@ -9,7 +9,7 @@ import life.qbic.datamodel.dtos.business.services.Product
  * @since: 1.0.0
  *
  */
-interface ArchiveProductOutput extends UseCaseFailure{
+interface ArchiveProductOutput extends UseCaseFailure {
 
     /**
      * A product has been archived in the database

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
@@ -1,0 +1,12 @@
+package life.qbic.business.products.copy
+
+/**
+ * <class short description - One Line!>
+ *
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since: <versiontag>
+ *
+ */
+class CopyProduct {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.products.copy
 
+import life.qbic.datamodel.dtos.business.ProductId
+
 /**
  * <class short description - One Line!>
  *
@@ -9,4 +11,8 @@ package life.qbic.business.products.copy
  *
  */
 class CopyProduct implements CopyProductInput {
+    @Override
+    void copy(ProductId productId) {
+
+    }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
@@ -3,11 +3,13 @@ package life.qbic.business.products.copy
 import life.qbic.datamodel.dtos.business.ProductId
 
 /**
- * <class short description - One Line!>
+ * <h1>4.3.2 Copy Service Product</h1>
+ * <br>
+ * <p> Offer Administrators are allowed to create a new permutation of an existing product.
+ * <br> New permutations can include changes in unit price, sequencing technology and other attributes of service products.
+ * </p>
  *
- * <More detailed description - When to use, what it solves, etc.>
- *
- * @since: <versiontag>
+ * @since: 1.0.0
  *
  */
 class CopyProduct implements CopyProductInput {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProduct.groovy
@@ -8,5 +8,5 @@ package life.qbic.business.products.copy
  * @since: <versiontag>
  *
  */
-class CopyProduct {
+class CopyProduct implements CopyProductInput {
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
@@ -1,0 +1,10 @@
+package life.qbic.business.products.copy
+
+/**
+ * Input interface for the {@link CopyProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+class CopyProductInput {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
@@ -1,10 +1,18 @@
 package life.qbic.business.products.copy
 
+import life.qbic.datamodel.dtos.business.ProductId
+
 /**
  * Input interface for the {@link CopyProduct} use case
  *
  * @since: 1.0.0
  *
  */
-class CopyProductInput {
+interface CopyProductInput {
+
+    /**
+     * The content of a product is going to be copied
+     * @param productId The id of the product that should be copied
+     */
+    void copy(ProductId productId)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductInput.groovy
@@ -13,6 +13,7 @@ interface CopyProductInput {
     /**
      * The content of a product is going to be copied
      * @param productId The id of the product that should be copied
+     * @since 1.0.0
      */
     void copy(ProductId productId)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
@@ -12,7 +12,7 @@ import life.qbic.datamodel.dtos.business.services.Product
 interface CopyProductOutput extends UseCaseFailure {
 
     /**
-     * A copy of a product has been created
+     * A copy of a product has been created. This method is called after the copied product has been stored in the database.
      * @param product The product that has been copied
      * @since 1.0.0
      */

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
@@ -1,10 +1,19 @@
 package life.qbic.business.products.copy
 
+import life.qbic.business.UseCaseFailure
+import life.qbic.datamodel.dtos.business.services.Product
+
 /**
  * Output interface for the {@link CopyProduct} use case
  *
  * @since: 1.0.0
  *
  */
-class CopyProductOutput {
+interface CopyProductOutput extends UseCaseFailure{
+
+    /**
+     * A copy of a product has been created
+     * @param product The product that has been copied
+     */
+    void copied(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
@@ -14,6 +14,7 @@ interface CopyProductOutput extends UseCaseFailure{
     /**
      * A copy of a product has been created
      * @param product The product that has been copied
+     * @since 1.0.0
      */
     void copied(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
@@ -1,0 +1,10 @@
+package life.qbic.business.products.copy
+
+/**
+ * Output interface for the {@link CopyProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+class CopyProductOutput {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/copy/CopyProductOutput.groovy
@@ -9,7 +9,7 @@ import life.qbic.datamodel.dtos.business.services.Product
  * @since: 1.0.0
  *
  */
-interface CopyProductOutput extends UseCaseFailure{
+interface CopyProductOutput extends UseCaseFailure {
 
     /**
      * A copy of a product has been created

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
@@ -8,5 +8,5 @@ package life.qbic.business.products.create
  * @since: <versiontag>
  *
  */
-class CreateProduct {
+class CreateProduct implements CreateProductInput {
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
@@ -1,0 +1,12 @@
+package life.qbic.business.products.create
+
+/**
+ * <class short description - One Line!>
+ *
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since: <versiontag>
+ *
+ */
+class CreateProduct {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
@@ -3,11 +3,13 @@ package life.qbic.business.products.create
 import life.qbic.datamodel.dtos.business.services.Product
 
 /**
- * <class short description - One Line!>
+ * <h1>4.3.0 Create Service Product</h1>
+ * <br>
+ * <p> When the service portfolio changed due to a business decision an Offer Administrator should be allowed to provide information on the new service offered and make it available to new offers upon creation.
+ * </p>
  *
- * <More detailed description - When to use, what it solves, etc.>
- *
- * @since: <versiontag>
+ * @since: 1.0.0
+
  *
  */
 class CreateProduct implements CreateProductInput {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProduct.groovy
@@ -1,5 +1,7 @@
 package life.qbic.business.products.create
 
+import life.qbic.datamodel.dtos.business.services.Product
+
 /**
  * <class short description - One Line!>
  *
@@ -9,4 +11,13 @@ package life.qbic.business.products.create
  *
  */
 class CreateProduct implements CreateProductInput {
+    @Override
+    void create(Product product) {
+
+    }
+
+    @Override
+    void createDuplicate(Product product) {
+
+    }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
@@ -13,6 +13,7 @@ interface CreateProductInput {
     /**
      * A product is created in the database
      * @param product The product that is added to the database
+     * @since 1.0.0
      */
     void create(Product product)
 
@@ -20,6 +21,7 @@ interface CreateProductInput {
      * Even though a duplicate product in the database exist a new product should be added.
      * The duplicate product is required to have a different product id!
      * @param product The product that should be added
+     * @since 1.0.0
      */
     void createDuplicate(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
@@ -19,7 +19,7 @@ interface CreateProductInput {
 
     /**
      * Even though a duplicate product in the database exist a new product should be added.
-     * The duplicate product is required to have a different product id!
+     * The new product will receive a new id that allows to differentiate it from the old product. The old id will be ignored.
      * @param product The product that should be added
      * @since 1.0.0
      */

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
@@ -1,0 +1,10 @@
+package life.qbic.business.products.create
+
+/**
+ * Input interface for the {@link CreateProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+class CreateProductInput {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductInput.groovy
@@ -1,10 +1,25 @@
 package life.qbic.business.products.create
 
+import life.qbic.datamodel.dtos.business.services.Product
+
 /**
  * Input interface for the {@link CreateProduct} use case
  *
  * @since: 1.0.0
  *
  */
-class CreateProductInput {
+interface CreateProductInput {
+
+    /**
+     * A product is created in the database
+     * @param product The product that is added to the database
+     */
+    void create(Product product)
+
+    /**
+     * Even though a duplicate product in the database exist a new product should be added.
+     * The duplicate product is required to have a different product id!
+     * @param product The product that should be added
+     */
+    void createDuplicate(Product product)
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
@@ -14,15 +14,16 @@ interface CreateProductOutput extends UseCaseFailure{
     /**
      * A product has been created in the database
      * @param product The product that has been created
+     * @since 1.0.0
      */
     void created(Product product)
 
     /**
      * The product is already stored in the database
      * @param product The product for which a duplicate has been found
+     * @since 1.0.0
      */
     void foundDuplicate(Product product)
 
 
 }
-

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
@@ -1,0 +1,10 @@
+package life.qbic.business.products.create
+
+/**
+ * Output interface for the {@link CreateProduct} use case
+ *
+ * @since: 1.0.0
+ *
+ */
+class CreateProductOutput {
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/create/CreateProductOutput.groovy
@@ -1,10 +1,28 @@
 package life.qbic.business.products.create
 
+import life.qbic.business.UseCaseFailure
+import life.qbic.datamodel.dtos.business.services.Product
+
 /**
  * Output interface for the {@link CreateProduct} use case
  *
  * @since: 1.0.0
  *
  */
-class CreateProductOutput {
+interface CreateProductOutput extends UseCaseFailure{
+
+    /**
+     * A product has been created in the database
+     * @param product The product that has been created
+     */
+    void created(Product product)
+
+    /**
+     * The product is already stored in the database
+     * @param product The product for which a duplicate has been found
+     */
+    void foundDuplicate(Product product)
+
+
 }
+


### PR DESCRIPTION
**Description of changes**
This PR adds the code structure for the interfaces of the service product maintenance interface

**Technical details**
Adapted the folder structure of the domain of the project and defined the interface method of the use cases CreateProduct, CopyProduct and ArchiveProduct

