### PR TITLE
Sort products into groups in the final offer PDF printout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,8 @@ Unassigned
 
 **Added**
 
-* Introduce subtotals in Offer PDF ProductItem Table(`#349 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/349>`_)
-* Introduce distinction between ProductItems with and without Overhead cost in Offer PDF(`#349 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/349>`_)
+* Introduce distinction of products in Offer PDF according to the associated service
+  (Data generation, Data analysis and Project Management)
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,8 @@ Unassigned
 **Added**
 
 * Introduce distinction of products in Offer PDF according to the associated service
-  (Data generation, Data analysis and Project Management)
+  Data generation, Data analysis and Project Management(`#364 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/364>`_)
+
 
 **Fixed**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Unassigned
 
 **Added**
 
-* Introduce distinction of products in Offer PDF according to the associated service
+* Introduce distinction of products in the offer PDF according to the associated service
   Data generation, Data analysis and Project Management(`#364 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/364>`_)
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ Unassigned
 **Added**
 
 * Introduce distinction of products in the offer PDF according to the associated service
-  Data generation, Data analysis and Project Management(`#364 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/364>`_)
+  data generation, data analysis and project management (`#364 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/364>`_)
 
 
 **Fixed**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -257,16 +257,13 @@ class OfferToPDFConverter implements OfferExporter {
 
     void generateProductTable(Map productItemsMap, int maxTableItems) {
         // Create the items in html in the overview table
-        productItemsMap.each {productGroup, items ->
+        productItemsMap.each { productGroup, items ->
             //Check if there are ProductItems stored in map entry
-            if (value) {
-                // set initial product item position in table
-                def itemPos = 1
-                // max number of table items per page
+            if(items){
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
-                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(key.toString()))
-                value.each {productItem ->
+                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup.toString()))
+                items.eachWithIndex { item, itemPos ->
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
                         ++tableCount
@@ -275,13 +272,12 @@ class OfferToPDFConverter implements OfferExporter {
                         tableItemsCount = 1
                     }
                     //add product to current table
-                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos++, productItem as ProductItem))
+                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos, item as ProductItem))
                     tableItemsCount++
                 }
             }
         }
     }
-
     /**
      * Small helper class to handle the HTML to PDF conversion.
      */

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -242,10 +242,6 @@ class OfferToPDFConverter implements OfferExporter {
                 dataManagementItems.add(it)
             }
         }
-            //Sort Lists by ProductName
-            dataGenerationItems = dataGenerationItems.sort{it.product.productName}
-            dataAnalysisItems = dataAnalysisItems.sort{it.product.productName}
-            dataManagementItems = dataManagementItems.sort{it.product.productName}
 
             //Map Lists to the "DataGeneration", "DataAnalysis" and "Project and Data Management"
             productItemsMap.dataGeneration = dataGenerationItems

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -257,7 +257,7 @@ class OfferToPDFConverter implements OfferExporter {
 
     void generateProductTable(Map productItemsMap, int maxTableItems) {
         // Create the items in html in the overview table
-        productItemsMap.each {key, value ->
+        productItemsMap.each {productGroup, items ->
             //Check if there are ProductItems stored in map entry
             if (value) {
                 // set initial product item position in table

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -169,8 +169,8 @@ class OfferToPDFConverter implements OfferExporter {
         List<ProductItem> listOverheadItems = offer.itemsWithOverhead
         List<ProductItem> listNoOverheadItems = offer.itemsWithoutOverhead
 
-        List<ProductItem> listDataGenerationItems = []
-        List<ProductItem> listDataAnalysisItems = []
+        List<ProductItem> dataGenerationItems = []
+        List<ProductItem> dataAnalysisItems = []
         // Sort ProductItems into DataGeneration and Data Analysis
         listOverheadItems.each {
             if (it.product instanceof Sequencing) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -398,26 +398,6 @@ class OfferToPDFConverter implements OfferExporter {
                                  </div>
                                  """
         }
-        static String subTotalFooter(double netCost, double overheadCost) {
 
-            double subtotalCost = netCost + overheadCost
-
-            return """
-            <div class="row sub-total-costs double-underscore" id = "sub-total">
-            <div class="col-6"></div>
-                    <div class="col-4 cost-summary-field">Total Cost:</div>
-            <div class="col-2 price-value" id="subtotal-value-total">${subtotalCost}</div>
-                    </div>
-            <div class="row total-costs" id = "subtotal-net">
-            <div class="col-10 cost-summary-field">Net Cost</div>
-                    <div class="col-2 price-value" id="subtotal-value-net">${netCost}</div>
-            </div>
-                    <div class="row total-costs" id ="subtotal-overhead">
-                    <div class="col-10 cost-summary-field">Overhead Cost:</div>
-            <div class="col-2 price-value" id="subtotal-value-overhead">${overheadCost}</div>
-            </div>
-            <div class ="small-spacer"> </div> 
-            """
-        }
         }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -203,11 +203,11 @@ class OfferToPDFConverter implements OfferExporter {
             String elementId = "product-items" + "-" + tableCount
             htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
             htmlContent.getElementById("item-table-grid")
-                    .append(ItemPrintout.tableFooter(offer.overheadRatio))
+                    .append(ItemPrintout.tableFooter())
         } else {
             //otherwise add total pricing to table
             htmlContent.getElementById("item-table-grid")
-                    .append(ItemPrintout.tableFooter(offer.overheadRatio))
+                    .append(ItemPrintout.tableFooter())
         }
         }
 
@@ -349,6 +349,7 @@ class OfferToPDFConverter implements OfferExporter {
                                          <div class="col-6"></div>
                                          <div class="col-4 cost-summary-field">Estimated total (net):</div>
                                          <div class="col-2 price-value" id="total-cost-value-net">12,500.00</div>
+                                         </div>
                                      <div class="row total-costs" id = "offer-vat">
                                          <div class="col-10 cost-summary-field">VAT (19%):</div>
                                          <div class="col-2 price-value" id="vat-cost-value">0.00</div>


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR addresses #359 by sorting the products according to their associated services("Data generation", "Data analysis " and "Project Management and Data storage") and productName in the Offer PDF. 
Additionally it removes the calculation methods for the subtotal tables and the methods used for the previous sorting of the products. 

**Additional context**
Adding the total net sum and overhead cost as required by #360 of the newly sorted products will be addressed in a seperate PR.
