### PR TITLE
Introduce subtotal footers to product groups in Offer PDF 

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -83,6 +83,38 @@ class OfferToPDFConverter implements OfferExporter {
                     .getResource("offer-template/stylesheet.css")
                     .toURI())
 
+    enum ProductGroups {
+        DATA_GENERATION("Data generation"),
+        DATA_ANALYSIS("Data analysis"),
+        DATA_MANAGEMENT("Project management and data storage")
+
+        private String name
+
+        private static final Map<String,String> ENUM_MAP
+
+        ProductGroups(String name) {
+            this.name = name;
+        }
+
+        String getName() {
+            return this.name;
+        }
+
+
+        // Build an immutable map storing the enum and its associated value
+        static {
+            HashMap<String, String> map = new HashMap<String, String>()
+            for (ProductGroups instance : ProductGroups.values()) {
+                map.put(instance.toString().toLowerCase(), instance.getName())
+            }
+            ENUM_MAP = Collections.unmodifiableMap(map)
+        }
+
+        static String get (String name) {
+            return ENUM_MAP.get(name.toLowerCase())
+        }
+    }
+
     OfferToPDFConverter(Offer offer) {
         this.offer = Objects.requireNonNull(offer, "Offer object must not be a null reference")
         this.tempDir = Files.createTempDirectory("offer")
@@ -244,9 +276,9 @@ class OfferToPDFConverter implements OfferExporter {
         }
 
             //Map Lists to the "DataGeneration", "DataAnalysis" and "Project and Data Management"
-            productItemsMap.dataGeneration = dataGenerationItems
-            productItemsMap.dataAnalysis = dataAnalysisItems
-            productItemsMap.dataManagement= dataManagementItems
+            productItemsMap[ProductGroups.DATA_GENERATION.toString()] = dataGenerationItems
+            productItemsMap[ProductGroups.DATA_ANALYSIS.toString()] = dataAnalysisItems
+            productItemsMap[ProductGroups.DATA_MANAGEMENT.toString()] = dataManagementItems
 
             return productItemsMap
         }
@@ -357,17 +389,9 @@ class OfferToPDFConverter implements OfferExporter {
 
         static String tableTitle(String productGroup){
 
-            String tableTitle = ""
+            String tableTitle
+            tableTitle = ProductGroups.get(productGroup)
 
-            if (productGroup == "dataGeneration"){
-                tableTitle = "Data Generation"
-            }
-            if (productGroup == "dataAnalysis"){
-                tableTitle = "Data Analysis"
-            }
-            if (productGroup == "dataManagement"){
-                tableTitle = "Data Management"
-            }
 
             return """<div class = "small-spacer"</div>
                     <h3>${tableTitle}</h3>
@@ -376,17 +400,8 @@ class OfferToPDFConverter implements OfferExporter {
 
         static String subTableFooter(String productGroup){
 
-            String footerTitle = ""
-
-            if (productGroup == "dataGeneration"){
-                footerTitle = "Data Generation"
-            }
-            if (productGroup == "dataAnalysis"){
-                footerTitle = "Data Analysis"
-            }
-            if (productGroup == "dataManagement"){
-                footerTitle = "Data Management"
-            }
+            String footerTitle
+            footerTitle = ProductGroups.get(productGroup)
 
             return """<div id="grid-sub-total-footer">
                                      <div class="row sub-total-costs" id = "offer-sub-total">

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -275,13 +275,13 @@ class OfferToPDFConverter implements OfferExporter {
 
     void generateProductTable(Map productItemsMap, int maxTableItems) {
         // Create the items in html in the overview table
-        productItemsMap.each {productGroup, items ->
+        productItemsMap.each {ProductGroups productGroup, List<ProductItem> items ->
             //Check if there are ProductItems stored in map entry
             if(items){
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
-                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup as ProductGroups))
-                items.eachWithIndex { item, itemPos ->
+                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup))
+                items.eachWithIndex {ProductItem item, int itemPos ->
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
                         ++tableCount
@@ -290,11 +290,11 @@ class OfferToPDFConverter implements OfferExporter {
                         tableItemsCount = 1
                     }
                     //add product to current table
-                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos, item as ProductItem))
+                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos, item))
                     tableItemsCount++
                 }
                 //add subtotal footer to table
-                htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup as ProductGroups))
+                htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup))
                 tableItemsCount++
             }
         }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -389,8 +389,7 @@ class OfferToPDFConverter implements OfferExporter {
 
         static String subTableFooter(ProductGroups productGroup){
 
-            String footerTitle
-            footerTitle = productGroup.getName()
+            String footerTitle = productGroup.getName()
 
             return """<div id="grid-sub-total-footer">
                                      <div class="row sub-total-costs" id = "offer-sub-total">

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -96,28 +96,12 @@ class OfferToPDFConverter implements OfferExporter {
 
         private String name
 
-        private static final Map<String,String> ENUM_MAP
-
         ProductGroups(String name) {
             this.name = name;
         }
 
         String getName() {
             return this.name;
-        }
-
-
-        // Build an immutable map storing the enum and its associated value
-        static {
-            HashMap<String, String> map = new HashMap<String, String>()
-            for (ProductGroups instance : ProductGroups.values()) {
-                map.put(instance.toString().toLowerCase(), instance.getName())
-            }
-            ENUM_MAP = Collections.unmodifiableMap(map)
-        }
-
-        static String get (String name) {
-            return ENUM_MAP.get(name.toLowerCase())
         }
     }
 
@@ -261,7 +245,7 @@ class OfferToPDFConverter implements OfferExporter {
 
     Map groupItems(List<ProductItem> productItems) {
 
-        def productItemsMap = [:]
+        Map<ProductGroups, List<ProductItem>> productItemsMap = [:]
 
         List<ProductItem> dataGenerationItems = []
         List<ProductItem> dataAnalysisItems = []
@@ -282,21 +266,21 @@ class OfferToPDFConverter implements OfferExporter {
         }
 
             //Map Lists to the "DataGeneration", "DataAnalysis" and "Project and Data Management"
-            productItemsMap[ProductGroups.DATA_GENERATION.toString()] = dataGenerationItems
-            productItemsMap[ProductGroups.DATA_ANALYSIS.toString()] = dataAnalysisItems
-            productItemsMap[ProductGroups.DATA_MANAGEMENT.toString()] = dataManagementItems
+            productItemsMap[ProductGroups.DATA_GENERATION] = dataGenerationItems
+            productItemsMap[ProductGroups.DATA_ANALYSIS] = dataAnalysisItems
+            productItemsMap[ProductGroups.DATA_MANAGEMENT] = dataManagementItems
 
             return productItemsMap
         }
 
     void generateProductTable(Map productItemsMap, int maxTableItems) {
         // Create the items in html in the overview table
-        productItemsMap.each { productGroup, items ->
+        productItemsMap.each {productGroup, items ->
             //Check if there are ProductItems stored in map entry
             if(items){
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
-                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup.toString()))
+                htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup as ProductGroups))
                 items.eachWithIndex { item, itemPos ->
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
@@ -310,7 +294,7 @@ class OfferToPDFConverter implements OfferExporter {
                     tableItemsCount++
                 }
                 //add subtotal footer to table
-                htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup.toString()))
+                htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup as ProductGroups))
                 tableItemsCount++
             }
         }
@@ -393,10 +377,10 @@ class OfferToPDFConverter implements OfferExporter {
                              """
         }
 
-        static String tableTitle(String productGroup){
+        static String tableTitle(ProductGroups productGroup){
 
             String tableTitle
-            tableTitle = ProductGroups.get(productGroup)
+            tableTitle = productGroup.getName()
 
 
             return """<div class = "small-spacer"</div>
@@ -404,10 +388,10 @@ class OfferToPDFConverter implements OfferExporter {
                    """
         }
 
-        static String subTableFooter(String productGroup){
+        static String subTableFooter(ProductGroups productGroup){
 
             String footerTitle
-            footerTitle = ProductGroups.get(productGroup)
+            footerTitle = productGroup.getName()
 
             return """<div id="grid-sub-total-footer">
                                      <div class="row sub-total-costs" id = "offer-sub-total">

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -83,6 +83,12 @@ class OfferToPDFConverter implements OfferExporter {
                     .getResource("offer-template/stylesheet.css")
                     .toURI())
 
+    /**
+     * Possible product groups
+     *
+     * This enum describes the product groups into which the products of an offer are listed.
+     *
+     */
     enum ProductGroups {
         DATA_GENERATION("Data generation"),
         DATA_ANALYSIS("Data analysis"),

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -379,8 +379,7 @@ class OfferToPDFConverter implements OfferExporter {
 
         static String tableTitle(ProductGroups productGroup){
 
-            String tableTitle
-            tableTitle = productGroup.getName()
+            String tableTitle= productGroup.getName()
 
 
             return """<div class = "small-spacer"</div>

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -271,6 +271,9 @@ class OfferToPDFConverter implements OfferExporter {
                     htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos, item as ProductItem))
                     tableItemsCount++
                 }
+                //add subtotal footer to table
+                htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup.toString()))
+                tableItemsCount++
             }
         }
     }
@@ -369,6 +372,38 @@ class OfferToPDFConverter implements OfferExporter {
             return """<div class = "small-spacer"</div>
                     <h3>${tableTitle}</h3>
                    """
+        }
+
+        static String subTableFooter(String productGroup){
+
+            String footerTitle = ""
+
+            if (productGroup == "dataGeneration"){
+                footerTitle = "Data Generation"
+            }
+            if (productGroup == "dataAnalysis"){
+                footerTitle = "Data Analysis"
+            }
+            if (productGroup == "dataManagement"){
+                footerTitle = "Data Management"
+            }
+
+            return """<div id="grid-sub-total-footer">
+                                     <div class="row sub-total-costs" id = "offer-sub-total">
+                                         <div class="col-6"></div> 
+                                         <div class="col-10 cost-summary-field">Estimated total (${footerTitle}):</div>
+                                         <div class="col-2 price-value" id="sub-total-costs-value">12345</div>
+                                         </div>
+                                     <div class="row sub-total-costs" id = "offer-sub-net">
+                                         <div class="col-10 cost-summary-field">Estimated net (${footerTitle}):</div>
+                                         <div class="col-2 price-value" id="sub-net-costs-value">12345</div>
+                                     </div>
+                                     <div class="row sub-total-costs" id ="offer-sub-overhead">
+                                         <div class="col-10 cost-summary-field">Estimated overhead (${footerTitle}):</div>
+                                         <div class="col-2 price-value" id="sub-overhead-costs-value">12345</div>
+                                     </div>
+                                 </div>
+                                 """
         }
 
         static String tableFooter(){

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -147,18 +147,18 @@
                         <div class="col-4 item-description">A more detailed description</div>
                         <div class="col-7"></div>
                     </div>
-                    <div class="row total-costs" id = "PB-total">
+                    <div class="row sub-total-costs" id = "sub-total">
                         <div class="col-6"></div>
                         <div class="col-4 cost-summary-field">Total Cost:</div>
-                        <div class="col-2 price-value" id="PB-value-total">4000</div>
+                        <div class="col-2 price-value" id="sub-total-value-total">4000</div>
                     </div>
-                    <div class="row total-costs" id = "PB-net">
+                    <div class="row sub-total-costs" id = "sub-total-net">
                         <div class="col-10 cost-summary-field">Net Cost</div>
-                        <div class="col-2 price-value" id="PB-value-net">3000</div>
+                        <div class="col-2 price-value" id="sub-total-value-net">3000</div>
                     </div>
-                    <div class="row total-costs" id ="PB-overhead">
+                    <div class="row sub-total-costs" id ="sub-total-overhead">
                         <div class="col-10 cost-summary-field">Overhead Cost:</div>
-                        <div class="col-2 price-value" id="PB-value-overhead">1000</div>
+                        <div class="col-2 price-value" id="sub-total-value-overhead">1000</div>
                 </div>
                 <div id="grid-table-footer">
                     <div class="row total-costs" id = "offer-net">

--- a/offer-manager-app/src/main/resources/offer-template/stylesheet.css
+++ b/offer-manager-app/src/main/resources/offer-template/stylesheet.css
@@ -174,6 +174,12 @@ body {
         padding: 10px 20px 2px 20px;
     }
 
+     #grid-sub-total-footer{
+            text-align: right;
+            border-top: 1px solid #bbbbbb;
+            padding: 10px 0px 2px 20px;
+        }
+
     .text-center{
         text-align: center;
     }


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
This PR reintroduces the subtotal footers for each product group in the offer pdf outlining the overhead, total and net cost for each group with dummy data as was requested in #360. 

![Bildschirmfoto 2021-03-11 um 15 40 56](https://user-images.githubusercontent.com/29627977/110804473-7e38ab80-8280-11eb-877e-3cb0dc530f4e.png)
