### PR TITLE
Adjust tests to new product id design

### DIFF
--- a/offer-manager-domain/src/test/groovy/life/qbic/business/products/archive/ArchiveProductSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/business/products/archive/ArchiveProductSpec.groovy
@@ -18,7 +18,7 @@ class ArchiveProductSpec extends Specification {
     def "archive provides the product from the datasource to the output"() {
 
         given: "a product identifier and associated product"
-        ProductId productId = new ProductId("Test", "Test1234")
+        ProductId productId = new ProductId("Test", "1234")
         Product product = new Product("Test", "Test Description", 0, ProductUnit.PER_SAMPLE, productId){}
 
         and: "an output and datasource that returns the product for a given productId"
@@ -39,7 +39,7 @@ class ArchiveProductSpec extends Specification {
     def "archive provides fail notification when no product was found "() {
 
         given: "a product identifier"
-        ProductId productId = new ProductId("Test", "Test1234")
+        ProductId productId = new ProductId("Test", "1234")
 
         and: "an output and datasource that cannot find the id"
         ArchiveProductDataSource dataSource = Stub()
@@ -58,7 +58,7 @@ class ArchiveProductSpec extends Specification {
 
     def "archive product outputs a fail notification in case the database query fails for technical reasons"() {
         given: "a product identifier and associated product"
-        ProductId productId = new ProductId("Test", "Test1234")
+        ProductId productId = new ProductId("Test", "1234")
         Product product = new Product("Test", "Test Description", 0, ProductUnit.PER_SAMPLE, productId){}
 
         and: "an output and datasource that fails for technical reasons"

--- a/offer-manager-domain/src/test/groovy/life/qbic/business/products/create/CreateProductSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/business/products/create/CreateProductSpec.groovy
@@ -21,7 +21,7 @@ class CreateProductSpec extends Specification {
 
     def setup() {
         output = Mock(CreateProductOutput)
-        productId = new ProductId("Test", "ABCD1234")
+        productId = new ProductId("Test", "1234")
         product = new AtomicProduct("test product", "this is a test product", 0.5, ProductUnit.PER_GIGABYTE, productId)
     }
 


### PR DESCRIPTION
Adjusts tests to only use numbers instead of numbers and alphabetic characters for productid setup