### PR TITLE
Start ProductListing with 1 in Offer PDF

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -325,7 +325,8 @@ class OfferToPDFConverter implements OfferExporter {
                         tableItemsCount = 1
                     }
                     //add product to current table
-                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemPos, item))
+                    int productNumber = itemPos + 1
+                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(productNumber, item))
                     tableItemsCount++
                 }
                 //add subtotal footer to table


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
This PR addresses #390 and starts the productlisting of the products in each productgroup table with 1 instead of 0 
