### PR TITLE
Fix Footer-Overflow and breaking in case of missing productgroups in Offer PDF 

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -209,7 +209,7 @@ class OfferToPDFConverter implements OfferExporter {
         generateProductTable(productItemsMap, maxTableItems)
 
         //Append total cost footer
-        if (tableItemsCount >= maxTableItems) {
+        if (tableItemsCount > maxTableItems) {
             //If currentTable is filled with Items generate new one and add total pricing there
             ++tableCount
             String elementId = "product-items" + "-" + tableCount
@@ -331,10 +331,10 @@ class OfferToPDFConverter implements OfferExporter {
                 }
                 //add subtotal footer to table
                 htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup))
-                tableItemsCount++
+                tableItemsCount = tableItemsCount + 2
+                // Update Footer Prices
+                setSubTotalPrices(productGroup, items)
             }
-            // Update Footer Prices
-            setSubTotalPrices(productGroup, items)
         }
     }
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -331,7 +331,11 @@ class OfferToPDFConverter implements OfferExporter {
                 }
                 //add subtotal footer to table
                 htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup))
-                tableItemsCount = tableItemsCount + 2
+                /* This variable indicates that the space which is normally reserved for 2 products,
+                 should be accounted for the subtotal Footer */
+                int productSpaceCount = 2
+
+                tableItemsCount = tableItemsCount + productSpaceCount
                 // Update Footer Prices
                 setSubTotalPrices(productGroup, items)
             }


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked

**Description of changes**
This PR is intended as a temporary fix for the footer overflow problem by increasing the space allocated for the subtotal footers. (See #389)
Additionally it fixes a break occuring if not all productgroups are filled with products

