### PR TITLE
Bump version in Changelog and pom.xml and qube.cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.0.0-alpha.5-SNAPSHOT
+--------------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
 1.0.0-alpha.4 (2021-03-16)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.0.0-alpha.5-SNAPSHOT
+1.0.0-alpha.5-SNAPSHOT (2021-03-17)
 --------------------------
 
 **Added**

--- a/offer-manager-app/pom.xml
+++ b/offer-manager-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>offer-manager</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.0.0-alpha.4</version>
+        <version>1.0.0-alpha.5-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>offer-manager-domain</artifactId>
-            <version>1.0.0-alpha.4</version>
+            <version>1.0.0-alpha.5-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/offer-manager-domain/pom.xml
+++ b/offer-manager-domain/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>offer-manager</artifactId>
 		<groupId>life.qbic</groupId>
-		<version>1.0.0-alpha.4</version>
+		<version>1.0.0-alpha.5-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<module>offer-manager-app</module>
 	</modules>
 	<artifactId>offer-manager</artifactId>
-	<version>1.0.0-alpha.4</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>1.0.0-alpha.5-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<groupId>life.qbic</groupId>
 	<name>The new offer manager</name>
 	<url>http://github.com/qbicsoftware/qOffer_2.0</url>

--- a/qube.cfg
+++ b/qube.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0-SNAPSHOT
+current_version = 1.0.0-alpha.5-SNAPSHOT
 
 [bumpversion_files_whitelisted]
 dot_qube = .qube.yml


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR updates the versioning from `1.0.0-alpha.4` to `1.0.0-alpha.5-SNAPSHOT` in all `pom.xml` files. Additionally it introduces the new version section into the changelog and sets the internal qube version to 1.0.0-alpha.5-SNAPSHOT. 

**Technical details**
I was not able to use QUBE to update the version since it doesn't recognize the alpha.X section of the version and fails with the following error: 
`Invalid version specified!
Ensure your version number has the form of 0.0.0 or 15.100.239-SNAPSHOT
`
