### PR TITLE
Introduces a fixed top percentage for notifications in stylesheet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,9 @@ an existing project by its project identifier.
 * Finalized the ``life.qbic.business.products.archive.ArchiveProduct`` and ``life/qbic/business/products/create/CreateProduct.groovy``
 use cases of the product maintenance and creation feature(`#411 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/411>`_).
 
-
 **Fixed**
+
+* Popup based Notifications are now properly centered in a liferay-environment(`#428 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/428>`_)
 
 **Dependencies**
 

--- a/offer-manager-app/src/main/webapp/VAADIN/themes/mytheme/styles.css
+++ b/offer-manager-app/src/main/webapp/VAADIN/themes/mytheme/styles.css
@@ -14453,6 +14453,7 @@ div.v-layout.v-horizontal.v-widget {
 	border-radius: 4px;
 	text-align: center;
 	position: fixed !important;
+	top: 50% !important;
 	-webkit-backface-visibility: hidden;
 	-moz-backface-visibility: hidden;
 	-ms-backface-visibility: hidden;

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 			<dependency>
 				<groupId>life.qbic</groupId>
 				<artifactId>data-model-lib</artifactId>
-				<version>2.4.0-SNAPSHOT</version>
+				<version>2.4.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
This PR addresses #399 by setting a default percentage value for the vertical position of the generated notification bar in the css style sheet. 

**Technical details**
Error notifications are shown in liferay in a generated div with the following classes: 
`v-Notification bar failure closable v-Notification-bar failure closable`  
Success notifications have the classes 
`v-Notification bar success closable v-Notification-bar success closable`   

Interestingly: the `bar` class specifies a top value of 597px and is set by liferay. 
This is normally not an issue since the notifications are also handled by liferay, but the Valo theme introduces the 
`position: fixed !important` attribute to the `v-Notification` class, which in conjunction with the numerical set top value results in a wrong position of the notification. (See [#7283](https://github.com/vaadin/framework/issues/7283))

Therefore the fixed top value from liferay has to be overriden(therefore the `!important` is necessary) in this case with a viewport percentage vertical value. 

**Additional context**
I included the fix in the portal-testing look and feel css so you can check it out there for testing purposes! 
<img width="1395" alt="Bildschirmfoto 2021-03-22 um 14 01 35" src="https://user-images.githubusercontent.com/29627977/111995846-b01bfe80-8b19-11eb-93ce-6713c0765d76.png">

