### PR TITLE
Fix/unstable products db connector #382

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -122,7 +122,13 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
     }
   }
 
-  def createOfferItems(List<ProductItem> items, int offerId) {
+  /**
+   * This method associates an offer with product items.
+   *
+   * @param items A list of product items of an offer
+   * @param offerId An offerId the references the offer that should contain the list of product items
+   */
+  void createOfferItems(List<ProductItem> items, int offerId) {
     items.each {productItem ->
       String query = "INSERT INTO productitem (productId, quantity, offerid) "+
               "VALUE(?,?,?)"

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -181,7 +181,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
    * @param productId String of productId stored in the DB e.g. "DS_1"
    * @return identifier Long of the iterative identifying part of the productId
    */
-  static long parseProductId(String productId) throws NumberFormatException{
+  private static long parseProductId(String productId) throws NumberFormatException{
     def splitId = productId.split("_")
     // The first entry [0] contains the product type which is assigned automatically, no need to parse it.
     String identifier = splitId[1]
@@ -195,7 +195,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
    * @param product A product for which the type needs to be determined
    * @return the type of the product or null
    */
-  static String getProductType(Product product){
+  private static String getProductType(Product product){
     if (product instanceof Sequencing) return 'Sequencing'
     if (product instanceof ProjectManagement) return 'Project Management'
     if (product instanceof PrimaryAnalysis) return 'Primary Bioinformatics'

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -126,7 +126,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
    * This method associates an offer with product items.
    *
    * @param items A list of product items of an offer
-   * @param offerId An offerId the references the offer that should contain the list of product items
+   * @param offerId An offerId which references the offer containing the list of product items
    */
   void createOfferItems(List<ProductItem> items, int offerId) {
     items.each {productItem ->


### PR DESCRIPTION
fixes #382 

The methods in the issue were in use so they should not be deprecated. Some of them were even used in another DbConnector so they should remain public. For all other methods, I introduced the private scope and defined the output type so the API is more concrete and only exposes the methods required from the outside.