### PR TITLE
Set up CopyProductView and CopyProductViewModel

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
@@ -617,7 +617,7 @@ class DependencyManager {
         try{
             copyProductView = new CopyProductView(copyProductViewModel, maintainProductController)
         }catch(Exception e){
-            log.error("Could not create ${CreateProductView.getSimpleName()} view.", e)
+            log.error("Could not create ${CopyProductView.getSimpleName()} view.", e)
             throw e
         }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -82,7 +82,7 @@ class MaintainProductsController {
             /**Product product = ProductConverter.createProduct(category, description, name, unitPrice, unit)
             copyProductInput.copyModified(product) */
         }catch(Exception unexpected){
-            log.error("unexpected exception at copy product call", unexpected)
+            log.error("Unexpected exception at copy product call", unexpected)
             throw new IllegalArgumentException("Could not copy product from provided arguments.")
         }
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -67,7 +67,7 @@ class MaintainProductsController {
     }
 
     /**
-     * Triggers the copy Use Case of a product
+     * Triggers the copy use case of a product
      *
      * @param category The products category which determines what kind of product is created
      * @param description The description of the product

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -77,7 +77,7 @@ class MaintainProductsController {
      */
     void copyProduct(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit, ProductId productId){
         try{
-            println("You did it!")
+       
             //ToDo how should the Id be provided to the Use Case?
             /**Product product = ProductConverter.createProduct(category, description, name, unitPrice, unit)
             copyProductInput.copyModified(product) */

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -74,20 +74,19 @@ class MaintainProductsController {
      * @param name The name of the product
      * @param unitPrice The unit price of the product
      * @param unit The unit in which the product is measured
+     * @param productId the productId of the to be copied product
      */
     void copyProduct(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit, ProductId productId){
         try{
-       
-            //ToDo how should the Id be provided to the Use Case?
-            /**Product product = ProductConverter.createProduct(category, description, name, unitPrice, unit)
-            copyProductInput.copyModified(product) */
+            Product product = ProductConverter.createProductWithVersion(category, description, name, unitPrice, unit, productId.uniqueId)
+            copyProductInput.copyModified(product)
         }catch(Exception unexpected){
             log.error("Unexpected exception at copy product call", unexpected)
             throw new IllegalArgumentException("Could not copy product from provided arguments.")
         }
     }
 
-    private static class ProductConverter{
+    private static class ProductConverter {
 
         /**
          * Creates a product DTO based on its products category
@@ -99,10 +98,23 @@ class MaintainProductsController {
          * @param unit The unit in which the product is measured
          * @return
          */
-        static Product createProduct(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit){
-            return Converter.createProduct(category,name, description, unitPrice,unit)
+        static Product createProduct(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit) {
+            return Converter.createProduct(category, name, description, unitPrice, unit)
         }
 
+        /**
+         * Creates a product DTO based on its products category and its ProductID
+         *
+         * @param category The products category which determines what kind of products is created
+         * @param description The description of the product
+         * @param name The name of the product
+         * @param unitPrice The unit price of the product
+         * @param unit The unit in which the product is measured
+         * @param productId the productID of the previous selected product
+         * @return
+         */
+        static Product createProductWithVersion(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit, long runningNumber) {
+            return Converter.createProductWithVersion(category, name, description, unitPrice, unit, runningNumber)
+        }
     }
-
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -4,17 +4,12 @@ import life.qbic.business.logging.Logger
 import life.qbic.business.logging.Logging
 import life.qbic.business.products.Converter
 import life.qbic.business.products.archive.ArchiveProductInput
+import life.qbic.business.products.copy.CopyProductInput
 import life.qbic.business.products.create.CreateProductInput
-
 import life.qbic.datamodel.dtos.business.ProductCategory
 import life.qbic.datamodel.dtos.business.ProductId
-import life.qbic.datamodel.dtos.business.services.DataStorage
-import life.qbic.datamodel.dtos.business.services.PrimaryAnalysis
 import life.qbic.datamodel.dtos.business.services.Product
 import life.qbic.datamodel.dtos.business.services.ProductUnit
-import life.qbic.datamodel.dtos.business.services.ProjectManagement
-import life.qbic.datamodel.dtos.business.services.SecondaryAnalysis
-import life.qbic.datamodel.dtos.business.services.Sequencing
 
 /**
  * <h1>Controls how the information flows into the use cases {@link life.qbic.business.products.create.CreateProduct} and {@link life.qbic.business.products.archive.ArchiveProduct}</h1>
@@ -28,12 +23,15 @@ class MaintainProductsController {
 
     private final CreateProductInput createProductInput
     private final ArchiveProductInput archiveProductInput
+    private final CopyProductInput copyProductInput
     private static final Logging log = Logger.getLogger(this.class)
 
     MaintainProductsController(CreateProductInput createProductInput,
-                               ArchiveProductInput archiveProductInput){
+                               ArchiveProductInput archiveProductInput,
+                               CopyProductInput copyProductInput){
         this.createProductInput = createProductInput
         this.archiveProductInput = archiveProductInput
+        this.copyProductInput = copyProductInput
     }
 
     /**
@@ -65,6 +63,27 @@ class MaintainProductsController {
         }catch(Exception unexpected){
             log.error("unexpected exception at archive product call", unexpected)
             throw new IllegalArgumentException("Could not archive products from provided arguments.")
+        }
+    }
+
+    /**
+     * Triggers the copy Use Case of a product
+     *
+     * @param category The products category which determines what kind of product is created
+     * @param description The description of the product
+     * @param name The name of the product
+     * @param unitPrice The unit price of the product
+     * @param unit The unit in which the product is measured
+     */
+    void copyProduct(ProductCategory category, String description, String name, double unitPrice, ProductUnit unit, ProductId productId){
+        try{
+            println("You did it!")
+            //ToDo how should the Id be provided to the Use Case?
+            /**Product product = ProductConverter.createProduct(category, description, name, unitPrice, unit)
+            copyProductInput.copyModified(product) */
+        }catch(Exception unexpected){
+            log.error("unexpected exception at copy product call", unexpected)
+            throw new IllegalArgumentException("Could not copy product from provided arguments.")
         }
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsPresenter.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager.components.product
 
 import life.qbic.business.products.archive.ArchiveProductOutput
+import life.qbic.business.products.copy.CopyProductOutput
 import life.qbic.business.products.create.CreateProductOutput
 import life.qbic.datamodel.dtos.business.services.Product
 import life.qbic.portal.offermanager.components.AppViewModel
@@ -13,7 +14,7 @@ import life.qbic.portal.offermanager.components.AppViewModel
  * @since 1.0.0
  *
  */
-class MaintainProductsPresenter implements CreateProductOutput, ArchiveProductOutput{
+class MaintainProductsPresenter implements CreateProductOutput, ArchiveProductOutput, CopyProductOutput{
 
     private final MaintainProductsViewModel productsViewModel
     private final AppViewModel mainViewModel
@@ -36,6 +37,11 @@ class MaintainProductsPresenter implements CreateProductOutput, ArchiveProductOu
     }
 
     @Override
+    void copied(Product product) {
+
+    }
+
+    @Override
     void foundDuplicate(Product product) {
         mainViewModel.failureNotifications << "Found duplicate product for $product.productId - $product.productName."
         //todo triggers sth in the view-model to ask the user if he still wants to create the duplicate
@@ -45,4 +51,5 @@ class MaintainProductsPresenter implements CreateProductOutput, ArchiveProductOu
     void failNotification(String notification) {
         mainViewModel.failureNotifications << notification
     }
+
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsPresenter.groovy
@@ -38,7 +38,8 @@ class MaintainProductsPresenter implements CreateProductOutput, ArchiveProductOu
 
     @Override
     void copied(Product product) {
-
+mainViewModel.successNotifications << "Successfully copied product $product.productId - $product.productName."
+        productsViewModel.productsResourcesService.addToResource(product)
     }
 
     @Override

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -175,6 +175,11 @@ class MaintainProductsView extends VerticalLayout{
             copyProductView.setVisible(false)
         })
 
+        copyProductView.createProductButton.addClickListener({
+            maintenanceLayout.setVisible(true)
+            copyProductView.setVisible(false)
+        })
+
         archiveProduct.addClickListener({
             controller.archiveProduct(viewModel.selectedProduct.productId)
         })

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -165,7 +165,7 @@ class MaintainProductsView extends VerticalLayout{
         })
 
         copyProduct.addClickListener({
-            viewModel.productUpdate.emit(viewModel.selectedProduct)
+            viewModel.productUpdate.emit(viewModel.selectedProduct.get())
             maintenanceLayout.setVisible(false)
             copyProductView.setVisible(true)
         })
@@ -181,7 +181,7 @@ class MaintainProductsView extends VerticalLayout{
         })
 
         archiveProduct.addClickListener({
-            controller.archiveProduct(viewModel.selectedProduct.productId)
+            controller.archiveProduct(viewModel.selectedProduct.get().productId)
         })
 
         viewModel.products.addPropertyChangeListener({
@@ -190,7 +190,7 @@ class MaintainProductsView extends VerticalLayout{
     }
 
     private void checkProductSelected() {
-        if (viewModel.selectedProduct) {
+        if (viewModel.selectedProduct.get()) {
             copyProduct.setEnabled(true)
             archiveProduct.setEnabled(true)
         } else {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -12,9 +12,9 @@ import com.vaadin.ui.VerticalLayout
 import com.vaadin.ui.components.grid.HeaderRow
 import com.vaadin.ui.themes.ValoTheme
 import life.qbic.business.offers.Currency
-import life.qbic.business.products.archive.ArchiveProduct
 import life.qbic.datamodel.dtos.business.services.Product
 import life.qbic.portal.offermanager.components.GridUtils
+import life.qbic.portal.offermanager.components.product.copy.CopyProductView
 import life.qbic.portal.offermanager.components.product.create.CreateProductView
 import life.qbic.portal.offermanager.dataresources.offers.OfferOverview
 
@@ -42,12 +42,15 @@ class MaintainProductsView extends VerticalLayout{
     VerticalLayout maintenanceLayout
 
     CreateProductView createProductView
+    CopyProductView copyProductView
 
     MaintainProductsView(MaintainProductsViewModel viewModel, CreateProductView createProductView,
+                         CopyProductView copyProductView,
                          MaintainProductsController controller){
         this.controller = controller
         this.viewModel = viewModel
         this.createProductView = createProductView
+        this.copyProductView = copyProductView
 
         setupPanel()
         createButtons()
@@ -68,8 +71,9 @@ class MaintainProductsView extends VerticalLayout{
     private void createButtons(){
         addProduct = new Button("Add Product", VaadinIcons.PLUS)
         copyProduct = new Button ("Copy Product", VaadinIcons.COPY)
-        copyProduct.setEnabled(false)
         archiveProduct = new Button("Archive Product", VaadinIcons.ARCHIVE)
+        copyProduct.setEnabled(false)
+        archiveProduct.setEnabled(false)
 
         buttonLayout = new HorizontalLayout(productDescription, addProduct,copyProduct,archiveProduct)
         buttonLayout.setMargin(false)
@@ -124,8 +128,10 @@ class MaintainProductsView extends VerticalLayout{
     }
 
     private void addSubViews(){
-        this.addComponents(createProductView) //todo add the copy product use case view here
+        this.addComponents(createProductView)
+        this.addComponent(copyProductView)
         createProductView.setVisible(false)
+        copyProductView.setVisible(false)
     }
 
     private void updateProductDescription(Product product){
@@ -143,7 +149,7 @@ class MaintainProductsView extends VerticalLayout{
         productGrid.addSelectionListener({
             if(it.firstSelectedItem.isPresent()){
                 updateProductDescription(it.firstSelectedItem.get())
-                viewModel.selectedProduct = it.firstSelectedItem.get()
+                viewModel.selectedProduct = it.firstSelectedItem
             }
         })
 
@@ -157,6 +163,17 @@ class MaintainProductsView extends VerticalLayout{
             createProductView.setVisible(false)
         })
 
+        copyProduct.addClickListener({
+            viewModel.productUpdate.emit(viewModel.selectedProduct)
+            maintenanceLayout.setVisible(false)
+            copyProductView.setVisible(true)
+        })
+
+        copyProductView.abortButton.addClickListener({
+            maintenanceLayout.setVisible(true)
+            copyProductView.setVisible(false)
+        })
+
         archiveProduct.addClickListener({
             controller.archiveProduct(viewModel.selectedProduct.productId)
         })
@@ -164,7 +181,20 @@ class MaintainProductsView extends VerticalLayout{
         viewModel.products.addPropertyChangeListener({
             productGrid.dataProvider.refreshAll()
         })
+        viewModel.addPropertyChangeListener({
+            checkProductSelected(viewModel)
+        })
 
+    }
+
+    private void checkProductSelected(MaintainProductsViewModel viewModel) {
+        if (viewModel.selectedProduct) {
+            copyProduct.setEnabled(true)
+            archiveProduct.setEnabled(true)
+        } else {
+            copyProduct.setEnabled(false)
+            archiveProduct.setEnabled(false)
+        }
     }
 
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -150,6 +150,7 @@ class MaintainProductsView extends VerticalLayout{
             if(it.firstSelectedItem.isPresent()){
                 updateProductDescription(it.firstSelectedItem.get())
                 viewModel.selectedProduct = it.firstSelectedItem
+                checkProductSelected()
             }
         })
 
@@ -181,13 +182,9 @@ class MaintainProductsView extends VerticalLayout{
         viewModel.products.addPropertyChangeListener({
             productGrid.dataProvider.refreshAll()
         })
-        viewModel.addPropertyChangeListener({
-            checkProductSelected(viewModel)
-        })
-
     }
 
-    private void checkProductSelected(MaintainProductsViewModel viewModel) {
+    private void checkProductSelected() {
         if (viewModel.selectedProduct) {
             copyProduct.setEnabled(true)
             archiveProduct.setEnabled(true)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsViewModel.groovy
@@ -51,11 +51,4 @@ class MaintainProductsViewModel {
         products.addAll(productsResourcesService.iterator().toList())
     }
 
-    Product getSelectedProduct() {
-        if(selectedProduct.isPresent()) {
-            return selectedProduct.get()
-        } else {
-            throw new RuntimeException("No product is currently selected.")
-        }
-    }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsViewModel.groovy
@@ -2,6 +2,8 @@ package life.qbic.portal.offermanager.components.product
 
 import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.datamodel.dtos.general.Person
+import life.qbic.portal.offermanager.communication.EventEmitter
 import life.qbic.portal.offermanager.dataresources.products.ProductsResourcesService
 
 
@@ -22,12 +24,14 @@ class MaintainProductsViewModel {
 
     ObservableList products = new ObservableList(new ArrayList<Product>())
 
-    @Bindable Product selectedProduct
+    @Bindable Optional<Product> selectedProduct
 
     final ProductsResourcesService productsResourcesService
+    EventEmitter<Product> productUpdate
 
-    MaintainProductsViewModel(ProductsResourcesService productsResourcesService) {
+    MaintainProductsViewModel(ProductsResourcesService productsResourcesService, EventEmitter<Product> productUpdate) {
         this.productsResourcesService = productsResourcesService
+        this.productUpdate = productUpdate
         fetchProducts()
         subscribe()
     }
@@ -45,5 +49,13 @@ class MaintainProductsViewModel {
     private void refreshList(){
         products.clear()
         products.addAll(productsResourcesService.iterator().toList())
+    }
+
+    Product getSelectedProduct() {
+        if(selectedProduct.isPresent()) {
+            return selectedProduct.get()
+        } else {
+            throw new RuntimeException("No product is currently selected.")
+        }
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
@@ -1,0 +1,41 @@
+package life.qbic.portal.offermanager.components.product.copy
+
+import com.vaadin.event.MouseEvents
+import com.vaadin.ui.Button
+import life.qbic.datamodel.dtos.business.ProductId
+import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.portal.offermanager.components.product.MaintainProductsController
+import life.qbic.portal.offermanager.components.product.create.CreateProductView
+
+
+/**
+ * <class short description - One Line!>
+ *
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since: <versiontag>
+ *
+ */
+
+class CopyProductView extends CreateProductView {
+
+    CopyProductViewModel copyProductViewModel
+    MaintainProductsController controller
+
+    CopyProductView(CopyProductViewModel copyProductViewModel, MaintainProductsController controller) {
+        super(copyProductViewModel, controller)
+        this.copyProductViewModel = copyProductViewModel
+        this.controller = controller
+        adaptView()
+    }
+
+    private void adaptView() {
+        createProductButton.setCaption("Copy Product")
+        label.setValue("Copy Service Product")
+        registration.remove()
+        this.createProductButton.addClickListener({
+            controller.copyProduct(viewModel.productCategory, viewModel.productDescription, viewModel.productName, Double.parseDouble(viewModel.productUnitPrice), viewModel.productUnit, copyProductViewModel.productId)
+        })
+    }
+
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
@@ -11,7 +11,7 @@ import life.qbic.portal.offermanager.components.product.create.CreateProductView
 /**
  * This class represents the GUI for copying a product
  *
- * The view is similar to the {@link CreateProductview} and updates the view to fit the copy product use case
+ * The view is similar to the {@link CreateProductView} and updates the view to fit the copy product use case
  *
  * @since: 1.0.0
  *
@@ -27,12 +27,16 @@ class CopyProductView extends CreateProductView {
         this.copyProductViewModel = copyProductViewModel
         this.controller = controller
         adaptView()
+        adaptListener()
     }
 
     private void adaptView() {
         createProductButton.setCaption("Copy Product")
-        label.setValue("Copy Service Product")
-        registration.remove()
+        titleLabel.setValue("Copy Service Product")
+    }
+
+    private void adaptListener() {
+        createProductButtonRegistration.remove()
         this.createProductButton.addClickListener({
             controller.copyProduct(viewModel.productCategory, viewModel.productDescription, viewModel.productName, Double.parseDouble(viewModel.productUnitPrice), viewModel.productUnit, copyProductViewModel.productId)
         })

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
@@ -9,11 +9,11 @@ import life.qbic.portal.offermanager.components.product.create.CreateProductView
 
 
 /**
- * <class short description - One Line!>
+ * This class represents the GUI for copying a product
  *
- * <More detailed description - When to use, what it solves, etc.>
+ * The view is similar to the {@link CreateProductview} and updates the view to fit the copy product use case
  *
- * @since: <versiontag>
+ * @since: 1.0.0
  *
  */
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
@@ -39,6 +39,7 @@ class CopyProductView extends CreateProductView {
         createProductButtonRegistration.remove()
         this.createProductButton.addClickListener({
             controller.copyProduct(viewModel.productCategory, viewModel.productDescription, viewModel.productName, Double.parseDouble(viewModel.productUnitPrice), viewModel.productUnit, copyProductViewModel.productId)
+            clearAllFields()
         })
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
@@ -1,0 +1,76 @@
+package life.qbic.portal.offermanager.components.product.copy
+
+import life.qbic.datamodel.dtos.business.Offer
+import life.qbic.datamodel.dtos.business.ProductCategory
+import life.qbic.datamodel.dtos.business.ProductId
+import life.qbic.datamodel.dtos.business.services.DataStorage
+import life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis
+import life.qbic.datamodel.dtos.business.services.PrimaryAnalysis
+import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.datamodel.dtos.business.services.ProjectManagement
+import life.qbic.datamodel.dtos.business.services.ProteomicAnalysis
+import life.qbic.datamodel.dtos.business.services.SecondaryAnalysis
+import life.qbic.datamodel.dtos.business.services.Sequencing
+import life.qbic.datamodel.dtos.general.Person
+import life.qbic.portal.offermanager.communication.EventEmitter
+import life.qbic.portal.offermanager.components.offer.create.ProductItemViewModel
+import life.qbic.portal.offermanager.components.product.MaintainProductsViewModel
+import life.qbic.portal.offermanager.components.product.create.CreateProductViewModel
+import life.qbic.portal.offermanager.dataresources.persons.CustomerResourceService
+import life.qbic.portal.offermanager.dataresources.persons.ProjectManagerResourceService
+import life.qbic.portal.offermanager.dataresources.products.ProductsResourcesService
+
+
+/**
+ * <h1>Holds all values that the user specifies in the CreateProductView</h1>
+ *
+ * @since 1.0.0
+ *
+*/
+class CopyProductViewModel extends CreateProductViewModel{
+
+    EventEmitter<Product> productUpdate
+    ProductId productId
+    CopyProductViewModel(EventEmitter<Product> productUpdate) {
+        super()
+        this.productUpdate = productUpdate
+        this.productUpdate.register((Product product) -> {
+            loadData(product)
+        })
+    }
+
+    private void loadData(Product product) {
+        productName = product.productName
+        productDescription = product.description
+        productUnit = product.unit
+        productUnitPrice = product.unitPrice
+        setProductCategory(product)
+        productId = product.productId
+    }
+
+    private ProductCategory setProductCategory(Product product){
+        switch(product.class) {
+            case DataStorage:
+                productCategory = ProductCategory.DATA_STORAGE
+                break
+            case PrimaryAnalysis:
+                productCategory = ProductCategory.PRIMARY_BIOINFO
+                break
+            case ProjectManagement:
+                productCategory = ProductCategory.PROJECT_MANAGEMENT
+                break
+            case SecondaryAnalysis:
+                productCategory = ProductCategory.SECONDARY_BIOINFO
+                break
+            case Sequencing:
+                productCategory = ProductCategory.SEQUENCING
+                break
+            case ProteomicAnalysis:
+                productCategory = ProductCategory.PROTEOMIC
+                break
+            case  MetabolomicAnalysis:
+                productCategory = ProductCategory.METABOLOMIC
+                break
+        }
+    }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.offermanager.components.product.copy
 
+import life.qbic.business.products.Converter
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.datamodel.dtos.business.ProductCategory
 import life.qbic.datamodel.dtos.business.ProductId
@@ -44,33 +45,7 @@ class CopyProductViewModel extends CreateProductViewModel{
         productDescription = product.description
         productUnit = product.unit
         productUnitPrice = product.unitPrice
-        setProductCategory(product)
+        productCategory = Converter.getCategory(product)
         productId = product.productId
-    }
-
-    private ProductCategory setProductCategory(Product product){
-        switch(product.class) {
-            case DataStorage:
-                productCategory = ProductCategory.DATA_STORAGE
-                break
-            case PrimaryAnalysis:
-                productCategory = ProductCategory.PRIMARY_BIOINFO
-                break
-            case ProjectManagement:
-                productCategory = ProductCategory.PROJECT_MANAGEMENT
-                break
-            case SecondaryAnalysis:
-                productCategory = ProductCategory.SECONDARY_BIOINFO
-                break
-            case Sequencing:
-                productCategory = ProductCategory.SEQUENCING
-                break
-            case ProteomicAnalysis:
-                productCategory = ProductCategory.PROTEOMIC
-                break
-            case  MetabolomicAnalysis:
-                productCategory = ProductCategory.METABOLOMIC
-                break
-        }
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -18,7 +18,7 @@ import com.vaadin.ui.themes.ValoTheme
 import life.qbic.datamodel.dtos.business.ProductCategory
 import life.qbic.datamodel.dtos.business.services.ProductUnit
 import life.qbic.portal.offermanager.components.product.MaintainProductsController
-
+import life.qbic.portal.offermanager.components.product.copy.CopyProductView
 /**
  * <h1>This view serves the user to create a new service product</h1>
  * <br>
@@ -38,12 +38,11 @@ class CreateProductView extends HorizontalLayout{
 
     ComboBox<String> productUnitComboBox
     ComboBox<String> productCategoryComboBox
-
-    Button createProductButton
     Button abortButton
 
+    /** These variables are adapted in the {@link CopyProductView} */
+    Button createProductButton
     Registration createProductButtonRegistration
-
     Label titleLabel
 
     CreateProductView(CreateProductViewModel createProductViewModel, MaintainProductsController controller){
@@ -60,16 +59,16 @@ class CreateProductView extends HorizontalLayout{
     }
 
     private void initLayout(){
-        label = new Label("Create Service Product")
-        label.setStyleName(ValoTheme.LABEL_HUGE)
-        this.addComponent(label)
+        titleLabel = new Label("Create Service Product")
+        titleLabel.setStyleName(ValoTheme.LABEL_HUGE)
+        this.addComponent(titleLabel)
 
         //add textfields and boxes
         HorizontalLayout sharedLayout = new HorizontalLayout(productUnitPriceField,productUnitComboBox)
         sharedLayout.setWidthFull()
         HorizontalLayout buttons = new HorizontalLayout(abortButton,createProductButton)
 
-        VerticalLayout sideLayout = new VerticalLayout(label,productNameField,productDescriptionField,sharedLayout,productCategoryComboBox,buttons)
+        VerticalLayout sideLayout = new VerticalLayout(titleLabel,productNameField,productDescriptionField,sharedLayout,productCategoryComboBox,buttons)
         sideLayout.setSizeFull()
         sideLayout.setComponentAlignment(buttons, Alignment.BOTTOM_RIGHT)
 
@@ -282,7 +281,7 @@ class CreateProductView extends HorizontalLayout{
     private void setupListeners(){
 
         abortButton.addClickListener({clearAllFields() })
-        registration = this.createProductButton.addClickListener({
+        createProductButtonRegistration = this.createProductButton.addClickListener({
             controller.createNewProduct(viewModel.productCategory, viewModel.productDescription,viewModel.productName, Double.parseDouble(viewModel.productUnitPrice),viewModel.productUnit)
         })
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -18,7 +18,7 @@ import com.vaadin.ui.themes.ValoTheme
 import life.qbic.datamodel.dtos.business.ProductCategory
 import life.qbic.datamodel.dtos.business.services.ProductUnit
 import life.qbic.portal.offermanager.components.product.MaintainProductsController
-import life.qbic.portal.offermanager.components.product.copy.CopyProductView
+
 /**
  * <h1>This view serves the user to create a new service product</h1>
  * <br>

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -42,7 +42,7 @@ class CreateProductView extends HorizontalLayout{
     Button createProductButton
     Button abortButton
 
-    Registration registration
+    Registration createProductButtonRegistration
 
     Label titleLabel
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -40,7 +40,6 @@ class CreateProductView extends HorizontalLayout{
     ComboBox<String> productCategoryComboBox
     Button abortButton
 
-    /** These variables are adapted in the {@link CopyProductView} */
     Button createProductButton
     Registration createProductButtonRegistration
     Label titleLabel

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -44,7 +44,7 @@ class CreateProductView extends HorizontalLayout{
 
     Registration registration
 
-    Label label
+    Label titleLabel
 
     CreateProductView(CreateProductViewModel createProductViewModel, MaintainProductsController controller){
         this.controller = controller

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -6,6 +6,7 @@ import com.vaadin.data.ValueContext
 import com.vaadin.data.validator.RegexpValidator
 import com.vaadin.icons.VaadinIcons
 import com.vaadin.server.UserError
+import com.vaadin.shared.Registration
 import com.vaadin.ui.Alignment
 import com.vaadin.ui.Button
 import com.vaadin.ui.ComboBox
@@ -28,8 +29,8 @@ import life.qbic.portal.offermanager.components.product.MaintainProductsControll
 */
 class CreateProductView extends HorizontalLayout{
 
-    private final CreateProductViewModel viewModel
-    private final MaintainProductsController controller
+    protected final CreateProductViewModel viewModel
+    protected final MaintainProductsController controller
 
     TextField productNameField
     TextField productDescriptionField
@@ -40,6 +41,10 @@ class CreateProductView extends HorizontalLayout{
 
     Button createProductButton
     Button abortButton
+
+    Registration registration
+
+    Label label
 
     CreateProductView(CreateProductViewModel createProductViewModel, MaintainProductsController controller){
         this.controller = controller
@@ -55,7 +60,7 @@ class CreateProductView extends HorizontalLayout{
     }
 
     private void initLayout(){
-        Label label = new Label("Create Service Product")
+        label = new Label("Create Service Product")
         label.setStyleName(ValoTheme.LABEL_HUGE)
         this.addComponent(label)
 
@@ -266,7 +271,7 @@ class CreateProductView extends HorizontalLayout{
      * It relies on the separate fields for validation.
      * @return
      */
-    private boolean allValuesValid() {
+    protected boolean allValuesValid() {
         return viewModel.productNameValid \
             && viewModel.productDescriptionValid \
             && viewModel.productUnitValid \
@@ -275,9 +280,9 @@ class CreateProductView extends HorizontalLayout{
     }
 
     private void setupListeners(){
-        abortButton.addClickListener({ clearAllFields() })
 
-        createProductButton.addClickListener({
+        abortButton.addClickListener({clearAllFields() })
+        registration = this.createProductButton.addClickListener({
             controller.createNewProduct(viewModel.productCategory, viewModel.productDescription,viewModel.productName, Double.parseDouble(viewModel.productUnitPrice),viewModel.productUnit)
         })
 
@@ -286,7 +291,7 @@ class CreateProductView extends HorizontalLayout{
     /**
      *  Clears User Input from all fields in the Create Products View and reset validation status of all Fields
      */
-    private void clearAllFields() {
+    protected void clearAllFields() {
 
         productNameField.clear()
         productDescriptionField.clear()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -4,6 +4,7 @@ import groovy.sql.GroovyRowResult
 import groovy.util.logging.Log4j2
 import life.qbic.business.products.Converter
 import life.qbic.business.products.archive.ArchiveProductDataSource
+import life.qbic.business.products.copy.CopyProductDataSource
 import life.qbic.business.products.create.CreateProductDataSource
 import life.qbic.business.products.create.ProductExistsException
 import life.qbic.datamodel.dtos.business.ProductCategory
@@ -26,7 +27,7 @@ import java.sql.SQLException
  * @since 1.0.0
  */
 @Log4j2
-class ProductsDbConnector implements ArchiveProductDataSource, CreateProductDataSource {
+class ProductsDbConnector implements ArchiveProductDataSource, CreateProductDataSource, CopyProductDataSource {
 
   private final ConnectionProvider provider
 


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR addresses #278 partially. 
It introduces the CopyProductView and CopyProductViewModel as extensions of the CreateProductView and CreateProductViewModel. 
It also sets up the connections in the DependencyManager to the domain logic. 
Lastly it connects the attributes of the selected Product in the MaintenanceProductView to the fields in the new CopyProductView. 

**Technical details**
The Scope of methods accessing the viewModel have to be set to protected for the ViewModel and View extension to function

**Additional context**
Add any other context or screenshots here.
