### PR TITLE
Fix country position for address

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Products that cannot be read from the database are skipped (`#444 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/444>`_)
 
+* Update position of country string in affiliation summary during customer creation (`#453 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -381,7 +381,8 @@ class CreatePersonView extends VerticalLayout {
                 content.addComponent(new Label("${affiliation.addressAddition}"))
             }
             content.addComponent(new Label("${affiliation.street}"))
-            content.addComponent(new Label("${affiliation.postalCode} ${affiliation.city} - ${affiliation.country}"))
+            content.addComponent(new Label("${affiliation.postalCode} ${affiliation.city}"))
+            content.addComponent(new Label("${affiliation.country}"))
             content.setMargin(true)
             content.setSpacing(false)
             this.affiliationDetails.setContent(content)


### PR DESCRIPTION
addresses partially #297 

fixes the display of the country in the address of an affiliation when selecting an affiliation in the customer/person creation process