### PR TITLE
Remove outdated person if its affiliations was updated 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,9 +34,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Proteomic and Metabolomic products can now be selected and included in an offer (`#425 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/425>`_)
 
-* Link offers to project now. The ``life.qbic.business.offers.Offer`` and
-  ``life.qbic.portal.offermanager.dataresources.offers`` have been extended
-  with a new property to associate it with an existing project by its project identifier.
+* Link offers to project now. The ``life.qbic.business.offers.Offer`` and ``life.qbic.portal.offermanager.dataresources.offers``
+  have been extended with a new property to associate it with
+  an existing project by its project identifier. (`#410 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/410>`_).
 
 * Finalized the ``life.qbic.business.products.archive.ArchiveProduct`` and ``life/qbic/business/products/create/CreateProduct.groovy``
   use cases of the product maintenance and creation feature (`#411 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/411>`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Harmonized Title and label structure across all views(`#455 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/455>`_)
 
-* Updating a customer now removes the old customer from the customerResourceService and in the grids(`#456 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/456>`_)
+* Updating a person removes the old entry also from the customerResourceService and projectManagerResourceService (`#456 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/456>`_)
 
 **Dependencies**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Popup based Notifications are now properly centered in a liferay-environment(`#428 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/428>`_)
 
 * Properly refresh the SearchPersonView after Updating a Person (`#436 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/436>`_)
+
 * Shows the same affiliation organisation only once and maps it correctly to the address addition (`#448 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/448>`_)
 
 * Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (`#452 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>`_)
@@ -40,6 +41,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Update position of country string in affiliation summary during customer creation (`#453 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>`_)
 
 * Input fields of the CreateProductView are cleared after successful product creation(`#454 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>`_)
+
+* Fix duplicate Person entries in the projectManagerService and customerService resulting from Update Person Use Case(`#454 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/456>`_)
 
 **Dependencies**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (`#452 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>`_)
 
+* Updating a customer now removes the old customer from the customerResourceService and in the grids(`#456 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/456>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager.components.offer.create
 
 import groovy.beans.Bindable
+import groovy.transform.EqualsAndHashCode
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.Offer
@@ -107,20 +108,28 @@ class CreateOfferViewModel {
         this.productsResourcesService.subscribe(productSubscription)
     }
 
-    private void refreshCustomers(){
+    /**
+     * This method replaces the foundCustomer list with the list provided by the customerResourceService
+     *
+     * This method will be triggered when a service event is triggered and is intended
+     * to refresh the customers shown in the grid with the ones currently stored in tce service
+     */
+    protected void refreshCustomers(){
         List<Customer> customers = customerResourceService.iterator().toList()
         this.foundCustomers.clear()
-        customers.each {customer ->
-            this.foundCustomers.add(customer)
-        }
+        foundCustomers.addAll(customers)
     }
 
-    private void refreshManagers(){
+    /**
+     * This method replaces the availableProjectManager list with the list provided by the managerResourceService
+     *
+     * This method will be triggered when a service event is triggered and is intended
+     * to refresh the project managers shown in the grid with the ones currently stored in the service
+     */
+    protected void refreshManagers(){
         List<ProjectManager> projectManagers = managerResourceService.iterator().toList()
         this.availableProjectManagers.clear()
-        projectManagers.each {manager ->
-            this.availableProjectManagers.add(manager)
-        }
+        availableProjectManagers.addAll(projectManagers)
     }
 
     private void refreshProducts(){

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
@@ -1,7 +1,6 @@
 package life.qbic.portal.offermanager.components.offer.create
 
 import groovy.beans.Bindable
-import groovy.transform.EqualsAndHashCode
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.Offer

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -32,9 +32,9 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
 
     UpdateOfferViewModel(CustomerResourceService customerResourceService,
                          ProjectManagerResourceService managerResourceService,
-                         ProductsResourcesService productsResourcesService,
+                         ProductsResourcesService productsService,
                          EventEmitter<Offer> offerUpdateEvent) {
-        super(customerResourceService, managerResourceService, productsResourcesService)
+        super(customerResourceService, managerResourceService, productsService)
         this.offerUpdate = offerUpdateEvent
 
         this.offerUpdate.register((Offer offer) -> {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -32,9 +32,9 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
 
     UpdateOfferViewModel(CustomerResourceService customerResourceService,
                          ProjectManagerResourceService managerResourceService,
-                         ProductsResourcesService productsService,
+                         ProductsResourcesService productsResourcesService,
                          EventEmitter<Offer> offerUpdateEvent) {
-        super(customerResourceService, managerResourceService, productsService)
+        super(customerResourceService, managerResourceService, productsResourcesService)
         this.offerUpdate = offerUpdateEvent
 
         this.offerUpdate.register((Offer offer) -> {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonPresenter.groovy
@@ -64,36 +64,26 @@ class CreatePersonPresenter implements CreatePersonOutput{
 
 
     void personCreated(Person person) {
-        Customer customer = new Customer.Builder(person.firstName,
-                person.lastName,
-                person.emailAddress)
-                .title(person.title)
-                .affiliations(person.affiliations).build()
-        ProjectManager manager = new ProjectManager.Builder(person.firstName,
-                person.lastName,
-                person.emailAddress)
-                .title(person.title)
-                .affiliations(person.affiliations).build()
+        Customer customer = translateToCustomer(person)
+        ProjectManager manager = translateToProjectManager(person)
         try{
             if (createPersonViewModel.outdatedPerson) {
-                    Customer foundCustomer
                     Iterator<Customer>  customerIterator = createPersonViewModel.customerService.iterator()
+                    Customer outdatedCustomer = translateToCustomer(createPersonViewModel.outdatedPerson)
                     customerIterator.each {
-                        if (isSamePerson(it, customer)) {
-                            foundCustomer = it
+                        if (it == outdatedCustomer) {
+                            createPersonViewModel.customerService.removeFromResource(it)
                         }
                     }
-                    ProjectManager foundManager
                     Iterator<ProjectManager>  managerIterator = createPersonViewModel.managerResourceService.iterator()
+                    ProjectManager outdatedManager = translateToProjectManager(createPersonViewModel.outdatedPerson)
                     managerIterator.each{
-                    if(isSamePerson(it, manager)) {
-                            foundManager = it
+                    if(it == outdatedManager) {
+                        createPersonViewModel.managerResourceService.removeFromResource(it)
                         }
                     }
-                    createPersonViewModel.customerService.removeFromResource(foundCustomer)
-                    createPersonViewModel.managerResourceService.removeFromResource(foundManager)
-                }
                 createPersonViewModel.personResourceService.removeFromResource(createPersonViewModel.outdatedPerson)
+                }
         }catch(Exception e){
             log.error e.message
             log.error e.stackTrace.join("\n")
@@ -105,15 +95,23 @@ class CreatePersonPresenter implements CreatePersonOutput{
         clearPersonData()
         viewModel.successNotifications.add("Successfully created new person entry.")
     }
-    // determines if customer properties other than affiliations have changed
-    //ToDo should there be an exception if the last name was changed(e.g. after marriage)s
-    private static boolean isSamePerson(Person existingPerson, Person newPerson) {
-        boolean sameAttributes = existingPerson.firstName.equals(newPerson.firstName)
-                && existingPerson.lastName.equals(newPerson.lastName)
-                && existingPerson.emailAddress.equals(newPerson.emailAddress)
-                && existingPerson.title.equals(newPerson.title)
 
-        return sameAttributes
+    private static Customer translateToCustomer(Person person){
+        Customer customer = new Customer.Builder(person.firstName,
+                person.lastName,
+                person.emailAddress)
+                .title(person.title)
+                .affiliations(person.affiliations).build()
+        return customer
+    }
+
+    private static ProjectManager translateToProjectManager(Person person){
+        ProjectManager manager = new ProjectManager.Builder(person.firstName,
+                person.lastName,
+                person.emailAddress)
+                .title(person.title)
+                .affiliations(person.affiliations).build()
+        return manager
     }
 
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonPresenter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonPresenter.groovy
@@ -75,18 +75,46 @@ class CreatePersonPresenter implements CreatePersonOutput{
                 .title(person.title)
                 .affiliations(person.affiliations).build()
         try{
-            if (createPersonViewModel.outdatedPerson) createPersonViewModel.personResourceService.removeFromResource(createPersonViewModel.outdatedPerson)
+            if (createPersonViewModel.outdatedPerson) {
+                    Customer foundCustomer
+                    Iterator<Customer>  customerIterator = createPersonViewModel.customerService.iterator()
+                    customerIterator.each {
+                        if (isSamePerson(it, customer)) {
+                            foundCustomer = it
+                        }
+                    }
+                    ProjectManager foundManager
+                    Iterator<ProjectManager>  managerIterator = createPersonViewModel.managerResourceService.iterator()
+                    managerIterator.each{
+                    if(isSamePerson(it, manager)) {
+                            foundManager = it
+                        }
+                    }
+                    createPersonViewModel.customerService.removeFromResource(foundCustomer)
+                    createPersonViewModel.managerResourceService.removeFromResource(foundManager)
+                }
+                createPersonViewModel.personResourceService.removeFromResource(createPersonViewModel.outdatedPerson)
         }catch(Exception e){
             log.error e.message
             log.error e.stackTrace.join("\n")
         }
-
         createPersonViewModel.customerService.addToResource(customer)
         createPersonViewModel.managerResourceService.addToResource(manager)
         createPersonViewModel.personResourceService.addToResource(person)
         //reset the view model
         clearPersonData()
-
         viewModel.successNotifications.add("Successfully created new person entry.")
     }
+    // determines if customer properties other than affiliations have changed
+    //ToDo should there be an exception if the last name was changed(e.g. after marriage)s
+    private static boolean isSamePerson(Person existingPerson, Person newPerson) {
+        boolean sameAttributes = existingPerson.firstName.equals(newPerson.firstName)
+                && existingPerson.lastName.equals(newPerson.lastName)
+                && existingPerson.emailAddress.equals(newPerson.emailAddress)
+                && existingPerson.title.equals(newPerson.title)
+
+        return sameAttributes
+    }
+
 }
+

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
@@ -88,4 +88,5 @@ class CreatePersonViewModel {
 
         return organisations
     }
+
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/CustomerResourceService.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/CustomerResourceService.groovy
@@ -29,7 +29,8 @@ class CustomerResourceService implements ResourcesService<Customer>{
 
     @Override
     void reloadResources() {
-
+        this.customerList.clear()
+        this.customerList.addAll(dbConnector.fetchAllCustomers())
     }
 
     @Override


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR addresses #405 by addressing the issue that updating an affiliation of a person doesn't remove the outdated person from the relevant services. 
This is done by comparing the relevant attributes of a person in the `CreateCustomerPresenter.` 
Additionally the customer and projectManager lists in the `createOfferViewModel` are now updated properly if changes in the customers/project managers occur. 

Lastly the variable naming is streamlined between the `createOfferViewModel` and `updateOfferViewModel`

** How to Test** 
1.) Click on `SearchCustomerView`
2.) Select a customer 
3.) Select affiliation which is not associated yet with the customer
4.) Update customer
5.) Go to `createOfferView/UpdateOfferView`  
6.) Check if selected person is updated with new affiliation in the `customerSelectionView `and `ProjectManagerView`


