### PR TITLE
Replace filter placeholder with explicit filter message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Proteomic and Metabolomic Products are now included in the Offer PDF
 
+* Filter message in grids is now dependent on column ID (`#457 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/457>`_)
+
 **Fixed**
 
 * Popup based Notifications are now properly centered in a liferay-environment(`#428 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/428>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -36,8 +36,11 @@ class GridUtils {
         })
         filterTextField.setValueChangeMode(ValueChangeMode.EAGER)
         filterTextField.addStyleName(ValoTheme.TEXTFIELD_TINY)
-        filterTextField.setPlaceholder("Filter Me")
-
+        String columnId = StringUtils.join(
+                StringUtils.splitByCharacterTypeCamelCase(column.id),
+                ' '
+        )
+        filterTextField.setPlaceholder("Filter by " + columnId)
         headerRow.getCell(column).setComponent(filterTextField)
         filterTextField.setSizeFull()
     }


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR replaces the standard "Filter Me" placeholder text in all grids with a more explicit "Filter by columnId" message such as:
![Bildschirmfoto 2021-04-06 um 14 06 34](https://user-images.githubusercontent.com/29627977/113708316-5a328380-96e1-11eb-8973-96c96f95391e.png)
 

