### PR TITLE
Bump version and move changelog to represent sprint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.0.0-alpha.6-SNAPSHOT (2021-04-07)
+1.0.0-alpha.6-SNAPSHOT (2021-04-08)
 -----------------------------------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.0.0-alpha.6-SNAPSHOT (2021-04-07)
+-----------------------------------
+
+**Added**
+
+* Filter message in grids is now dependent on column ID (`#457 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/457>`_)
+
+**Fixed**
+
+* Update position of country string in affiliation summary during customer creation (`#453 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>`_)
+
+* Input fields of the CreateProductView are cleared after successful product creation(`#454 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>`_)
+
+* Shows the same affiliation organisation only once and maps it correctly to the address addition (`#448 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/448>`_)
+
+* Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (`#452 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>`_)
+
+**Dependencies**
+
+**Deprecated**
 
 1.0.0-alpha.5 (2021-04-07)
 -----------------------------------
@@ -26,23 +46,13 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Proteomic and Metabolomic Products are now included in the Offer PDF (`#420 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/420>`_)
 
-* Filter message in grids is now dependent on column ID (`#457 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/457>`_)
-
 **Fixed**
 
 * Popup based Notifications are now properly centered in a liferay-environment(`#428 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/428>`_)
 
 * Properly refresh the SearchPersonView after Updating a Person (`#436 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/436>`_)
 
-* Shows the same affiliation organisation only once and maps it correctly to the address addition (`#448 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/448>`_)
-
-* Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (`#452 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>`_)
-
 * Products that cannot be read from the database are skipped (`#444 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/444>`_)
-
-* Update position of country string in affiliation summary during customer creation (`#453 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>`_)
-
-* Input fields of the CreateProductView are cleared after successful product creation(`#454 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>`_)
 
 **Dependencies**
 

--- a/offer-manager-app/pom.xml
+++ b/offer-manager-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>offer-manager</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.0.0-alpha.5</version>
+        <version>1.0.0-alpha.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>offer-manager-domain</artifactId>
-            <version>1.0.0-alpha.5</version>
+            <version>1.0.0-alpha.6-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/offer-manager-domain/pom.xml
+++ b/offer-manager-domain/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>offer-manager</artifactId>
 		<groupId>life.qbic</groupId>
-		<version>1.0.0-alpha.5</version>
+		<version>1.0.0-alpha.6-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<module>offer-manager-app</module>
 	</modules>
 	<artifactId>offer-manager</artifactId>
-	<version>1.0.0-alpha.5</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>1.0.0-alpha.6-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<groupId>life.qbic</groupId>
 	<name>The new offer manager</name>
 	<url>http://github.com/qbicsoftware/qOffer_2.0</url>

--- a/qube.cfg
+++ b/qube.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0-alpha.5
+current_version = 1.0.0-alpha.6-SNAPSHOT
 
 [bumpversion_files_whitelisted]
 dot_qube = .qube.yml


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR updates the Changelog and the version in the pom.xml to 1.0.0-alpha.6-SNAPSHOT and moves the iterables down in the current sprint to this section in the Changelog. 
