### PR TITLE
Add 'add affiliation' button to update person

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (`#452 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>`_)
 
+* Make adding a new affiliation more intuitive (`#467 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/467>`_) (`#463 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/463>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -44,6 +44,8 @@ class CreatePersonView extends VerticalLayout {
     Button abortButton
     Panel affiliationDetails
 
+    HorizontalLayout buttonLayout
+
     CreatePersonView(CreatePersonController controller, AppViewModel sharedViewModel, CreatePersonViewModel createPersonViewModel) {
         super()
         this.controller = controller
@@ -111,7 +113,7 @@ class CreatePersonView extends VerticalLayout {
         VerticalLayout affiliationPanel = new VerticalLayout(affiliationDetails)
         affiliationPanel.setMargin(false)
         affiliationPanel.setComponentAlignment(affiliationDetails, Alignment.TOP_LEFT)
-        HorizontalLayout buttonLayout = new HorizontalLayout(abortButton,
+        buttonLayout = new HorizontalLayout(abortButton,
                 submitButton)
         buttonLayout.setMargin(false)
         HorizontalLayout row4 = new HorizontalLayout(affiliationPanel, buttonLayout)
@@ -269,12 +271,12 @@ class CreatePersonView extends VerticalLayout {
                 createPersonViewModel.emailValid = true
             }
         })
-        this.organisationComboBox.addSelectionListener({ selection ->
-            ValidationResult result = selectionValidator.apply(selection.getValue(), new ValueContext(this.organisationComboBox))
+        this.addressAdditionComboBox.addSelectionListener({ selection ->
+            ValidationResult result = selectionValidator.apply(selection.getValue(), new ValueContext(this.addressAdditionComboBox))
             if (result.isError()) {
                 createPersonViewModel.affiliationValid = false
                 UserError error = new UserError(result.getErrorMessage())
-                organisationComboBox.setComponentError(error)
+                addressAdditionComboBox.setComponentError(error)
             } else {
                 createPersonViewModel.affiliationValid = true
             }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -198,6 +198,7 @@ class UpdatePersonView extends CreatePersonView{
     private void resetAffiliation(){
         organisationComboBox.selectedItem = organisationComboBox.clear()
         addressAdditionComboBox.selectedItem = addressAdditionComboBox.clear()
+        addressAdditionComboBox.setComponentError(null)
     }
 
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -163,9 +163,9 @@ class UpdatePersonView extends CreatePersonView{
                 updatePersonViewModel.personUpdated = true
             }else{
                 sharedViewModel.failureNotifications.add("Cannot add the selected affiliation. It was already associated with the person.")
-                resetAffiliation()
                 addAffiliationButton.setEnabled(false)
             }
+            resetAffiliation()
         })
 
         updatePersonViewModel.addPropertyChangeListener({it ->

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -200,6 +200,14 @@ class UpdatePersonView extends CreatePersonView{
         addressAdditionComboBox.selectedItem = addressAdditionComboBox.clear()
     }
 
+    /**
+     * This is used to indicate whether all fields of this view are filled correctly.
+     * It relies on the separate fields for validation. It overrides the Method allValuesValid() of the CreatePersonView
+     * and makes the validity independent of an added affiliation. Furthermore, the person entry needs to be different to
+     * the person that needs to be updated.
+     *
+     * @return boolean which indicates if a person update can be triggered
+     */
     protected boolean allValuesValid() {
         return createPersonViewModel.firstNameValid \
             && createPersonViewModel.lastNameValid \

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -1,7 +1,9 @@
 package life.qbic.portal.offermanager.components.person.update
 
 import com.vaadin.data.provider.ListDataProvider
+import com.vaadin.icons.VaadinIcons
 import com.vaadin.shared.ui.grid.HeightMode
+import com.vaadin.ui.Button
 import com.vaadin.ui.Grid
 import com.vaadin.ui.components.grid.HeaderRow
 import groovy.util.logging.Log4j2
@@ -25,6 +27,7 @@ class UpdatePersonView extends CreatePersonView{
     private final AppViewModel sharedViewModel
 
     private Grid<Affiliation> affiliations
+    private Button addAffiliationButton
 
 
     UpdatePersonView(CreatePersonController controller, AppViewModel sharedViewModel, UpdatePersonViewModel updatePersonViewModel) {
@@ -44,8 +47,13 @@ class UpdatePersonView extends CreatePersonView{
         generateAffiliationGrid()
         affiliations.setCaption("Current Affiliations")
         this.addComponent(affiliations,2)
-affiliations.setSelectionMode(Grid.SelectionMode.NONE)
+        affiliations.setSelectionMode(Grid.SelectionMode.NONE)
         //add the add button
+        addAffiliationButton = new Button("Add Affiliation")
+        addAffiliationButton.setIcon(VaadinIcons.PLUS)
+        addAffiliationButton.setEnabled(false)
+
+        buttonLayout.addComponent(addAffiliationButton,0)
     }
 
     private void generateAffiliationGrid() {
@@ -120,11 +128,9 @@ affiliations.setSelectionMode(Grid.SelectionMode.NONE)
                 String firstName = updatePersonViewModel.firstName
                 String lastName = updatePersonViewModel.lastName
                 String email = updatePersonViewModel.email
-                List<Affiliation> affiliations = new ArrayList()
-                affiliations.add(updatePersonViewModel.affiliation)
+                List<Affiliation> affiliations = updatePersonViewModel.affiliationList
 
                 if(updatePersonViewModel.outdatedPerson){
-                    affiliations.addAll(updatePersonViewModel.outdatedPerson.affiliations)
                     controller.updatePerson(updatePersonViewModel.outdatedPerson, firstName, lastName, title, email, affiliations)
                 }
 
@@ -138,5 +144,17 @@ affiliations.setSelectionMode(Grid.SelectionMode.NONE)
             }
         })
 
+        updatePersonViewModel.addPropertyChangeListener("affiliationValid",{
+            if(updatePersonViewModel.affiliationValid){
+                addAffiliationButton.setEnabled(true)
+            }else{
+                addAffiliationButton.setEnabled(false)
+            }
+        })
+        addAffiliationButton.addClickListener({
+            if(!updatePersonViewModel.affiliationList.contains(updatePersonViewModel.affiliation)) updatePersonViewModel.affiliationList << updatePersonViewModel.affiliation
+            addAffiliationButton.setEnabled(false)
+            affiliations.dataProvider.refreshAll()
+        })
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.offermanager.components.person.update
 
+import groovy.beans.Bindable
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.general.Person
@@ -31,6 +32,8 @@ class UpdatePersonViewModel extends CreatePersonViewModel{
     final private EventEmitter<Person> customerUpdate
     ObservableList affiliationList
 
+    @Bindable Boolean personUpdated
+
     UpdatePersonViewModel(CustomerResourceService customerService,
             ProjectManagerResourceService managerResourceService,
             AffiliationResourcesService affiliationService,
@@ -39,10 +42,11 @@ class UpdatePersonViewModel extends CreatePersonViewModel{
         super(customerService, managerResourceService, affiliationService, personResourceService)
         this.customerUpdate = customerUpdate
         affiliationList = new ArrayList<Affiliation>()
+        personUpdated = false
 
         this.customerUpdate.register((Person person) -> {
-            loadData(person)
             setOutdatedPerson(person)
+            loadData(person)
         })
     }
 


### PR DESCRIPTION
Addresses #440 

This PR adds a button to add a new affiliation for a person when updating it. 

It also adjusts when an affiliation is valid by making the validity depending on the addressAdditionCombobox instead of the organisationComobox. This is required to allow to enable the add button correctly.
