### PR TITLE
Add date filter to offer overview grid

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -9,6 +9,7 @@ import com.vaadin.ui.components.grid.HeaderRow
 import com.vaadin.ui.themes.ValoTheme
 import org.apache.commons.lang3.StringUtils
 
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.chrono.ChronoLocalDate
 
@@ -64,12 +65,21 @@ class GridUtils {
         DateField dateFilterField = new DateField()
         dateFilterField.addValueChangeListener(event -> {
             dataProvider.addFilter(element ->
-                    Date.from(dateFilterField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant()).equals(column.getValueProvider().apply(element))
+                    isSameDate(dateFilterField.getValue(), column.getValueProvider().apply(element))
             )
         })
         dateFilterField.addStyleName(ValoTheme.DATEFIELD_TINY)
 
         headerRow.getCell(column).setComponent(dateFilterField)
         dateFilterField.setSizeFull()
+    }
+
+    private static boolean isSameDate(LocalDate localDate, Date date){
+        try{
+            Date dateFromLocal = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+            return dateFromLocal == date
+        }catch(Exception ignore){
+            return false
+        }
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -67,7 +67,7 @@ class GridUtils {
                     Date.from(dateFilterField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant()).equals(column.getValueProvider().apply(element))
             )
         })
-        dateFilterField.addStyleName(ValoTheme.TEXTFIELD_TINY)
+        dateFilterField.addStyleName(ValoTheme.DATEFIELD_TINY)
 
         headerRow.getCell(column).setComponent(dateFilterField)
         dateFilterField.setSizeFull()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -2,11 +2,15 @@ package life.qbic.portal.offermanager.components
 
 import com.vaadin.data.provider.ListDataProvider
 import com.vaadin.shared.ui.ValueChangeMode
+import com.vaadin.ui.DateField
 import com.vaadin.ui.Grid
 import com.vaadin.ui.TextField
 import com.vaadin.ui.components.grid.HeaderRow
 import com.vaadin.ui.themes.ValoTheme
 import org.apache.commons.lang3.StringUtils
+
+import java.time.ZoneId
+import java.time.chrono.ChronoLocalDate
 
 /**
  * A helper class with static utility functions for Vaadin Grids.
@@ -43,5 +47,30 @@ class GridUtils {
         filterTextField.setPlaceholder("Filter by " + columnId)
         headerRow.getCell(column).setComponent(filterTextField)
         filterTextField.setSizeFull()
+    }
+
+    /**
+     * Provides a filter field into a header row of a grid for a given column of type Date.
+     *
+     * The current implementation filters a date column based on day and month
+     *
+     * @param dataProvider The grid's {@link ListDataProvider}
+     * @param column The date column to add the filter to
+     * @param headerRow The{@link com.vaadin.ui.components.grid.HeaderRow} of the {@link Grid}, where the filter input field is added
+     */
+    static <T> void setupDateColumnFilter(ListDataProvider<T> dataProvider,
+                                      Grid.Column<T, Date> column,
+                                      HeaderRow headerRow) {
+        DateField dateFilterField = new DateField()
+        dateFilterField.addValueChangeListener(event -> {
+            dataProvider.addFilter(element ->
+                    Date.from(dateFilterField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant()).equals(column.getValueProvider().apply(element))
+            )
+        })
+        //filterTextField.setValueChangeMode(ValueChangeMode.EAGER)
+        //filterTextField.addStyleName(ValoTheme.TEXTFIELD_TINY)
+
+        headerRow.getCell(column).setComponent(dateFilterField)
+        dateFilterField.setSizeFull()
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -52,7 +52,7 @@ class GridUtils {
     /**
      * Provides a filter field into a header row of a grid for a given column of type Date.
      *
-     * The current implementation filters a date column based on day and month
+     * The current implementation filters a date column based on a picked date
      *
      * @param dataProvider The grid's {@link ListDataProvider}
      * @param column The date column to add the filter to
@@ -67,8 +67,7 @@ class GridUtils {
                     Date.from(dateFilterField.getValue().atStartOfDay(ZoneId.systemDefault()).toInstant()).equals(column.getValueProvider().apply(element))
             )
         })
-        //filterTextField.setValueChangeMode(ValueChangeMode.EAGER)
-        //filterTextField.addStyleName(ValoTheme.TEXTFIELD_TINY)
+        dateFilterField.addStyleName(ValoTheme.TEXTFIELD_TINY)
 
         headerRow.getCell(column).setComponent(dateFilterField)
         dateFilterField.setSizeFull()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -19,6 +19,7 @@ import com.vaadin.ui.themes.ValoTheme
 import com.vaadin.ui.Grid.Column
 import com.vaadin.ui.renderers.TextRenderer
 import groovy.util.logging.Log4j2
+
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.portal.offermanager.components.offer.overview.projectcreation.CreateProjectView
 import life.qbic.portal.offermanager.dataresources.offers.OfferOverview
@@ -127,8 +128,9 @@ class OfferOverviewView extends FormLayout {
     }
 
     private void setupGrid() {
-        def dateColumn = overviewGrid.addColumn({ overview -> overview.getModificationDate() })
+        Column<Offer, Date> dateColumn = overviewGrid.addColumn({ overview -> overview.getModificationDate() })
                 .setCaption("Creation Date").setId("CreationDate")
+        //dateColumn.setRenderer(date -> Date.AMERICAN_DATE_FORMAT.format(date), new TextRenderer())
         overviewGrid.addColumn({overview -> overview.offerId.toString()})
                 .setCaption("Offer ID").setId("OfferId")
         overviewGrid.addColumn({overview -> overview.getProjectTitle()})
@@ -152,6 +154,7 @@ class OfferOverviewView extends FormLayout {
 
     private void setupFilters(ListDataProvider<OfferOverview> offerOverviewDataProvider) {
         HeaderRow customerFilterRow = overviewGrid.appendHeaderRow()
+
         GridUtils.setupColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("OfferId"),
                 customerFilterRow)
@@ -160,6 +163,9 @@ class OfferOverviewView extends FormLayout {
                 customerFilterRow)
         GridUtils.setupColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("Customer"),
+                customerFilterRow)
+        GridUtils.setupDateColumnFilter(offerOverviewDataProvider,
+                overviewGrid.getColumn("CreationDate"),
                 customerFilterRow)
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -130,7 +130,6 @@ class OfferOverviewView extends FormLayout {
     private void setupGrid() {
         Column<Offer, Date> dateColumn = overviewGrid.addColumn({ overview -> overview.getModificationDate() })
                 .setCaption("Creation Date").setId("CreationDate")
-        //dateColumn.setRenderer(date -> Date.AMERICAN_DATE_FORMAT.format(date), new TextRenderer())
         overviewGrid.addColumn({overview -> overview.offerId.toString()})
                 .setCaption("Offer ID").setId("OfferId")
         overviewGrid.addColumn({overview -> overview.getProjectTitle()})


### PR DESCRIPTION
Solves #402

This PR adds the possibility to filter for dates.

For now it is only filtered for a specific date, based on the stakeholder feedback it is easy to adjust it to allow to filter for time points e.g. for all offers after or before a specific date.