### PR TITLE
Release 1.0.0-alpha.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,10 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Replace 'customer' with 'person' in menu bar for the headings 'create customer' and 'search person' (`#473 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/473>`_)
 
+* Update position of country string in affiliation summary during customer creation (`#453 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>`_)
+
+* Input fields of the CreateProductView are cleared after successful product creation(`#454 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -41,8 +41,11 @@ class GridUtils {
         })
         filterTextField.setValueChangeMode(ValueChangeMode.EAGER)
         filterTextField.addStyleName(ValoTheme.TEXTFIELD_TINY)
-        filterTextField.setPlaceholder("Filter Me")
-
+        String columnId = StringUtils.join(
+                StringUtils.splitByCharacterTypeCamelCase(column.id),
+                ' '
+        )
+        filterTextField.setPlaceholder("Filter by " + columnId)
         headerRow.getCell(column).setComponent(filterTextField)
         filterTextField.setSizeFull()
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CustomerSelectionView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CustomerSelectionView.groovy
@@ -217,25 +217,31 @@ class CustomerSelectionView extends VerticalLayout{
     private void bindViewModel() {
 
         customerGrid.addSelectionListener({ selection ->
-            //vaadin is in single selection mode, selecting the first item will be fine
-            List<Affiliation> affiliations = customerGrid.getSelectedItems().getAt(0).affiliations
-            Customer customer = customerGrid.getSelectedItems().getAt(0)
+            if(selection.firstSelectedItem.isPresent()){
+                Customer selectedCustomer = selection.getFirstSelectedItem().get()
+                //vaadin is in single selection mode, selecting the first item will be fine
+                List<Affiliation> affiliations = selectedCustomer.affiliations
 
-            viewModel.customer = customer
-            // We explicitly reset any existing selected affiliation, as the user
-            // must provide it again after changing the customer.
-            viewModel.customerAffiliation = null
+                viewModel.customer = selectedCustomer
+                // We explicitly reset any existing selected affiliation, as the user
+                // must provide it again after changing the customer.
+                viewModel.customerAffiliation = null
 
-            //todo do we need to clear the grid for another selection?
-            affiliationGrid.setItems(affiliations)
+                //todo do we need to clear the grid for another selection?
+                affiliationGrid.setItems(affiliations)
 
-            affiliationSelectionContainer.setVisible(true)
+                affiliationSelectionContainer.setVisible(true)
+            }else{
+                affiliationSelectionContainer.setVisible(false)
+            }
 
         })
 
         affiliationGrid.addSelectionListener({
-            Affiliation affiliation = affiliationGrid.getSelectedItems().getAt(0)
-            viewModel.customerAffiliation = affiliation
+            if(it.firstSelectedItem.isPresent()){
+                Affiliation affiliation = it.firstSelectedItem.get()
+                viewModel.customerAffiliation = affiliation
+            }
         })
 
         /*

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
@@ -36,7 +36,7 @@ class CreatePersonViewModel {
     @Bindable Boolean emailValid
     @Bindable Boolean affiliationValid
 
-    ObservableList availableAffiliations
+    ObservableList availableOrganisations
 
     final CustomerResourceService customerService
     final ProjectManagerResourceService managerResourceService
@@ -51,10 +51,18 @@ class CreatePersonViewModel {
         this.customerService = customerService
         this.managerResourceService = managerResourceService
         this.personResourceService = personResourceService
-        availableAffiliations = new ObservableList(new ArrayList<Affiliation>(affiliationService.iterator().collect()))
+        List<Affiliation> affiliations = affiliationService.iterator().collect()
+        availableOrganisations = new ObservableList(new ArrayList<Organisation>(toOrganisation(affiliations)))
 
         this.affiliationService.subscribe({
-            if (! (it in this.availableAffiliations) ) this.availableAffiliations.add(it)
+            List foundOrganisations = availableOrganisations.findAll(){organisation -> (organisation as Organisation).name == it.organisation}
+            if(foundOrganisations.empty){
+                //create a new organisation
+                availableOrganisations << new Organisation(it.organisation,[it])
+            }else{
+                //add the new affiliation
+                (foundOrganisations.get(0) as Organisation).affiliations << it
+            }
         })
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -282,6 +282,7 @@ class CreateProductView extends HorizontalLayout{
         abortButton.addClickListener({clearAllFields() })
         createProductButtonRegistration = this.createProductButton.addClickListener({
             controller.createNewProduct(viewModel.productCategory, viewModel.productDescription,viewModel.productName, Double.parseDouble(viewModel.productUnitPrice),viewModel.productUnit)
+            clearAllFields()
         })
 
     }


### PR DESCRIPTION
1.0.0-alpha.6 (2021-04-13)
-----------------------------------

**Added**

* Filter message in grids is now dependent on column ID (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/457>)

* Add link to item table in offer pdf (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/469>)

**Fixed**

* Allow natural sorting of prices by their double value as opposed to their String representation (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/458>)

* Update position of country string in affiliation summary during customer creation (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>)

* Input fields of the CreateProductView are cleared after successful product creation(<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>)

* Shows the same affiliation organisation only once and maps it correctly to the address addition (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/448>)

* Fix fail based on double clicking a customer in the SelectCustomerView for in the offer creation process (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/452>)

* Make adding a new affiliation more intuitive (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/467>) (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/463>)

* Harmonized Title and label structure across all views (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/455>)

* Updating a person removes the old entry also from the customerResourceService and projectManagerResourceService (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/456>)

* Make empty address addition explicitly selectable during person creation and update (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/474>)

* Replace 'customer' with 'person' in menu bar for the headings 'create customer' and 'search person' (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/473>)

* Update position of country string in affiliation summary during customer creation (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/453>)

* Input fields of the CreateProductView are cleared after successful product creation(<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/454>)

**Dependencies**

**Deprecated**