### PR TITLE
Add experimental design to offer-domain and view

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferController.groovy
@@ -51,7 +51,8 @@ class CreateOfferController {
             Customer customer,
             ProjectManager manager,
             List<ProductItem> items,
-            Affiliation customerAffiliation){
+            Affiliation customerAffiliation,
+            String experimentalDesign){
 
         Offer offer = new Offer.Builder(
                     customer,
@@ -61,6 +62,7 @@ class CreateOfferController {
                     customerAffiliation)
                     .items(items)
                     .identifier(offerId)
+                    .experimentalDesign(experimentalDesign)
                     .build()
 
         this.input.createOffer(offer)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferView.groovy
@@ -43,8 +43,7 @@ class CreateOfferView extends FormLayout{
                     CreateOfferController controller,
                     CreatePersonView createCustomerView,
                     CreateAffiliationView createAffiliationView,
-                    OfferResourcesService offerProviderService
-    ) {
+                    OfferResourcesService offerProviderService) {
         super()
         this.sharedViewModel = sharedViewModel
         this.viewModel = createOfferViewModel
@@ -159,7 +158,8 @@ class CreateOfferView extends FormLayout{
                     viewModel.customer,
                     viewModel.projectManager,
                     getProductItems(viewModel.productItems),
-                    viewModel.customerAffiliation)
+                    viewModel.customerAffiliation,
+                    viewModel.experimentalDesign)
         })
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/CreateOfferViewModel.groovy
@@ -42,6 +42,7 @@ class CreateOfferViewModel {
     @Bindable OfferId offerId
     @Bindable String projectTitle
     @Bindable String projectObjective
+    @Bindable String experimentalDesign
     @Bindable Customer customer
     @Bindable Affiliation customerAffiliation
     @Bindable ProjectManager projectManager

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/OfferOverviewView.groovy
@@ -157,6 +157,7 @@ class OfferOverviewView extends VerticalLayout{
         VerticalLayout projectInfo = new VerticalLayout()
         projectInfo.addComponent(new Label("${createOfferViewModel.projectTitle}"))
         projectInfo.addComponent(new Label("${createOfferViewModel.projectObjective}"))
+        if(createOfferViewModel.experimentalDesign) projectInfo.addComponent(new Label("${createOfferViewModel.experimentalDesign}"))
         projectInfo.addComponent(new Label("${createOfferViewModel.customer}"))
         projectInfo.addComponent(new Label("${createOfferViewModel.customerAffiliation}"))
         projectInfo.addComponent(new Label("${createOfferViewModel.projectManager}"))

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/ProjectInformationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/ProjectInformationView.groovy
@@ -27,6 +27,7 @@ class ProjectInformationView extends VerticalLayout {
 
     TextField projectTitle
     TextArea projectObjective
+    TextArea experimentalDesign
     Button next
 
     ProjectInformationView(CreateOfferViewModel createOfferViewModel) {
@@ -50,11 +51,17 @@ class ProjectInformationView extends VerticalLayout {
         projectObjective.setRequiredIndicatorVisible(true)
         projectObjective.setSizeFull()
 
+        this.experimentalDesign = new TextArea("Experimental Design")
+        experimentalDesign.setPlaceholder("Enter the experimental design here")
+        //todo is it required
+        experimentalDesign.setRequiredIndicatorVisible(true)
+        experimentalDesign.setSizeFull()
+
         this.next = new Button(VaadinIcons.CHEVRON_CIRCLE_RIGHT)
         next.addStyleName(ValoTheme.LABEL_LARGE)
         next.setEnabled(false)
 
-        VerticalLayout textLayout = new VerticalLayout(projectTitle, projectObjective)
+        VerticalLayout textLayout = new VerticalLayout(projectTitle, projectObjective, experimentalDesign)
         textLayout.setComponentAlignment(projectTitle, Alignment.TOP_CENTER)
         textLayout.setComponentAlignment(projectObjective, Alignment.BOTTOM_CENTER)
         textLayout.setSizeFull()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/ProjectInformationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/create/ProjectInformationView.groovy
@@ -53,8 +53,6 @@ class ProjectInformationView extends VerticalLayout {
 
         this.experimentalDesign = new TextArea("Experimental Design")
         experimentalDesign.setPlaceholder("Enter the experimental design here")
-        //todo is it required
-        experimentalDesign.setRequiredIndicatorVisible(true)
         experimentalDesign.setSizeFull()
 
         this.next = new Button(VaadinIcons.CHEVRON_CIRCLE_RIGHT)
@@ -89,6 +87,8 @@ class ProjectInformationView extends VerticalLayout {
                 .bind({ it.projectTitle }, { it, updatedValue -> it.setProjectTitle(updatedValue) })
         binder.forField(projectObjective)
                 .bind({ it.projectObjective }, { it, updatedValue -> it.setProjectObjective(updatedValue) })
+        binder.forField(experimentalDesign)
+                .bind({ it.experimentalDesign }, { it, updatedValue -> it.setExperimentalDesign(updatedValue) })
 
 
         /*
@@ -110,6 +110,10 @@ class ProjectInformationView extends VerticalLayout {
                 case "projectObjective":
                     String newValue = it.newValue as String
                     projectObjective.value = newValue ?: projectObjective.emptyValue
+                    break
+                case "experimentalDesign":
+                    String newValue = it.newValue as String
+                    experimentalDesign.value = newValue ?: experimentalDesign.emptyValue
                     break
                 default:
                     break

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -49,6 +49,7 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
         super.customer = offer.customer
         super.customerAffiliation = offer.selectedCustomerAffiliation
         super.projectManager = offer.projectManager
+        super.experimentalDesign = offer.experimentalDesign
         super.productItems.clear()
         super.productItems.addAll(offer.items.collect {
             new ProductItemViewModel(it.quantity, it.product)})

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Converter.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Converter.groovy
@@ -49,6 +49,10 @@ class Converter {
             builder.associatedProject(offer.associatedProject.get())
         }
 
+        if(offer.experimentalDesign.isPresent()){
+            builder.experimentalDesign(offer.experimentalDesign.get())
+        }
+
         return builder.build()
     }
     static Offer buildOfferForCostCalculation(List<ProductItem> items,
@@ -88,6 +92,7 @@ class Converter {
                 offer.projectDescription,
                 offer.items,
                 offer.selectedCustomerAffiliation)
+                .experimentalDesign(offer.experimentalDesign)
                 .identifier(buildOfferId(offer.identifier))
                 //ToDo Is this the correct mapping?
                 .creationDate(offer.modificationDate)

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -60,6 +60,10 @@ class Offer {
      */
     private String projectObjective
     /**
+     * A short description of the experimental design of the project
+     */
+    private Optional<String> experimentalDesign
+    /**
      * A list of items for which the customer will be charged
      */
     private List<ProductItem> items
@@ -124,6 +128,7 @@ class Offer {
         ProjectManager projectManager
         String projectTitle
         String projectObjective
+        Optional<String> experimentalDesign
         List<ProductItem> items
         OfferId identifier
         Affiliation selectedCustomerAffiliation
@@ -139,6 +144,7 @@ class Offer {
             this.items = []
             this.availableVersions = []
             this.creationDate = new Date()
+            this.experimentalDesign = Optional.empty()
             // Since the incoming item list is mutable we need to
             // copy all immutable items to out internal list
             items.each {this.items.add(it)}
@@ -171,6 +177,10 @@ class Offer {
             return this
         }
 
+        Builder experimentalDesign(Optional<String> experimentalDesign){
+            this.experimentalDesign = experimentalDesign
+            return this
+        }
 
         Offer build() {
             return new Offer(this)
@@ -186,6 +196,13 @@ class Offer {
         this.creationDate = builder.creationDate
         this.projectManager = builder.projectManager
         this.projectObjective = builder.projectObjective
+
+        if (builder.experimentalDesign.isPresent()) {
+            this.experimentalDesign = builder.experimentalDesign
+        } else {
+            this.experimentalDesign = Optional.empty()
+        }
+
         this.projectTitle = builder.projectTitle
         this.selectedCustomerAffiliation = builder.selectedCustomerAffiliation
         this.overhead = determineOverhead()
@@ -350,6 +367,10 @@ class Offer {
 
     String getProjectObjective() {
         return projectObjective
+    }
+
+    Optional<String> getExperimentalDesign(){
+        return experimentalDesign
     }
 
     List<ProductItem> getItems() {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
@@ -58,8 +58,6 @@ class CreateOffer implements CreateOfferInput, CalculatePrice, UpdateOfferOutput
                 .identifier(newOfferId)
                 .build()
 
-        println offerContent.experimentalDesign
-
         storeOffer(finalizedOffer)
     }
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
@@ -58,6 +58,8 @@ class CreateOffer implements CreateOfferInput, CalculatePrice, UpdateOfferOutput
                 .identifier(newOfferId)
                 .build()
 
+        println offerContent.experimentalDesign
+
         storeOffer(finalizedOffer)
     }
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/create/CreateOffer.groovy
@@ -54,6 +54,7 @@ class CreateOffer implements CreateOfferInput, CalculatePrice, UpdateOfferOutput
                 offerContent.projectDescription,
                 offerContent.items,
                 offerContent.selectedCustomerAffiliation)
+                .experimentalDesign(offerContent.experimentalDesign)
                 .identifier(newOfferId)
                 .build()
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
@@ -62,6 +62,7 @@ class UpdateOffer{
     private void storeOffer() {
         try {
             final offer = Converter.convertOfferToDTO(offerToUpdate)
+            println offer.experimentalDesign
             dataSource.store(offer)
             output.updatedOffer(offer)
         } catch (Exception e) {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
@@ -62,7 +62,6 @@ class UpdateOffer{
     private void storeOffer() {
         try {
             final offer = Converter.convertOfferToDTO(offerToUpdate)
-            println offer.experimentalDesign
             dataSource.store(offer)
             output.updatedOffer(offer)
         } catch (Exception e) {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/update/UpdateOffer.groovy
@@ -97,6 +97,7 @@ class UpdateOffer{
                 offer.projectDescription,
                 offer.items,
                 offer.selectedCustomerAffiliation)
+                .experimentalDesign(offer.experimentalDesign)
                 .identifier(Converter.buildOfferId(offer.identifier))
                 .build()
     }

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -88,7 +88,9 @@ class OfferSpec extends Specification {
         when: "we create an offer with that id"
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
                 "awesome project", items, internalAffiliation)
-                .identifier(offerId)build()
+                .identifier(offerId)
+                .experimentalDesign(Optional.of("this is a design"))
+                .build()
         offer.addAllAvailableVersions(versions)
 
         then: "the latest version must be 4"

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
@@ -74,7 +74,7 @@ class CreateOfferSpec extends Specification {
         ]
 
         Offer offer = new Offer.Builder(customer, projectManager, projectTitle, projectDescription, selectedAffiliation)
-                .modificationDate(date).expirationDate(date).items([items[0]])
+                .modificationDate(date).expirationDate(date).items([items[0]]).experimentalDesign("A design")
                 .build()
 
         when:


### PR DESCRIPTION
This PR addresses #263 and adds the experimental design to the view and the domain.

To test if the changes are working I also committed two println's for update and create offer. So you can test if the experimental design is correctly delegated to the use case.

The update of the database will be implemented in a separate PR.