### PR TITLE
Add timeout to rendering subprocess

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
-* Add timeout of 1 second to PDF rendering
+* Add timeout of 10 second to PDF rendering
 
 
 **Dependencies**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 1.0.0-alpha.7-SNAPSHOT (2021-04-14)
---------------------------
+-----------------------------------
 
 **Added**
 
@@ -13,7 +13,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
-* Add timeout of 10 second to PDF rendering
+* Add timeout of 10 second to PDF rendering (`#494 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/494>`_)
 
 
 **Dependencies**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Add timeout of 1 second to PDF rendering
+
+
 **Dependencies**
 
 **Deprecated**
@@ -138,7 +141,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Update offers without changes is not possible anymore (`#222 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/222>`_)
 
-* Rename CreateCustomer and UpdateCustomer classes and methods (`#315 https://github.com/qbicsoftware/offer-manager-2-portlet/issues/315`_)
+* Rename CreateCustomer and UpdateCustomer classes and methods (`#315 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/315>`_)
 
 **Dependencies**
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -25,6 +25,7 @@ import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.text.DateFormat
 import java.text.DecimalFormat
+import java.util.concurrent.TimeUnit
 
 /**
  * Handles the conversion of offers to pdf files
@@ -394,7 +395,7 @@ class OfferToPDFConverter implements OfferExporter {
             builder.directory(new File(sourceFile.getParent().toString()))
             builder.redirectErrorStream(true)
             Process process = builder.start()
-            process.waitFor()
+            process.waitFor(1, TimeUnit.SECONDS)
             process.getInputStream().eachLine {log.info(it)}
             if (! new File(output.toString()).exists()) {
                 throw new RuntimeException("Offer PDF has not been generated.")

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -395,7 +395,7 @@ class OfferToPDFConverter implements OfferExporter {
             builder.directory(new File(sourceFile.getParent().toString()))
             builder.redirectErrorStream(true)
             Process process = builder.start()
-            process.waitFor(1, TimeUnit.SECONDS)
+            process.waitFor(10, TimeUnit.SECONDS)
             process.getInputStream().eachLine {log.info(it)}
             if (! new File(output.toString()).exists()) {
                 throw new RuntimeException("Offer PDF has not been generated.")


### PR DESCRIPTION
Many thanks for contributing to this project!

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
The sub-process responsible for rendering the PDF from the HTML template terminates after a given amount of time (10 seconds).

**Technical details**
We use chromium as a renderer in a headless state. Since a failure of the rendering does not necessarily terminate the chromium process, the waitFor can, in certain cases, block the portlet indefinitely. 

