### PR TITLE
Add experimental design to offerdbconnector

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Product selection now notifies a user if the provided input is incorrect and disables the button until the given information is valid (`#407 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/407>`_)
 
+* Experimental designs can be defined for an offer (`#263 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/263>` _)
+
 **Fixed**
 
 * Add timeout of 10 second to PDF rendering (`#494 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/494>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -49,7 +49,7 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
         super.customer = offer.customer
         super.customerAffiliation = offer.selectedCustomerAffiliation
         super.projectManager = offer.projectManager
-        super.experimentalDesign = offer.experimentalDesign.isPresent() ? offer.experimentalDesign.get() : ""
+        super.experimentalDesign = offer.experimentalDesign.orElse("")
         super.productItems.clear()
         super.productItems.addAll(offer.items.collect {
             new ProductItemViewModel(it.quantity, it.product)})

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewModel.groovy
@@ -49,7 +49,7 @@ class UpdateOfferViewModel extends CreateOfferViewModel{
         super.customer = offer.customer
         super.customerAffiliation = offer.selectedCustomerAffiliation
         super.projectManager = offer.projectManager
-        super.experimentalDesign = offer.experimentalDesign
+        super.experimentalDesign = offer.experimentalDesign.isPresent() ? offer.experimentalDesign.get() : ""
         super.productItems.clear()
         super.productItems.addAll(offer.items.collect {
             new ProductItemViewModel(it.quantity, it.product)})

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
@@ -2,11 +2,14 @@ package life.qbic.portal.offermanager.dataresources.offers
 
 import groovy.util.logging.Log4j2
 import life.qbic.business.offers.fetch.FetchOfferDataSource
+import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.OfferId
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.Offer
 import life.qbic.business.exceptions.DatabaseQueryException
 import life.qbic.business.offers.create.CreateOfferDataSource
+import life.qbic.datamodel.dtos.business.ProductItem
+import life.qbic.datamodel.dtos.business.ProjectManager
 import life.qbic.datamodel.dtos.projectmanagement.ProjectCode
 import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
 import life.qbic.datamodel.dtos.projectmanagement.ProjectSpace
@@ -253,32 +256,32 @@ class OfferDbConnector implements CreateOfferDataSource, FetchOfferDataSource, P
                 /*
                 Load the offer Id first
                  */
-                def fetchedOfferId = parseOfferId(resultSet.getString("offerId"))
-                def offerPrimaryId = resultSet.getInt("id")
+                OfferId fetchedOfferId = parseOfferId(resultSet.getString("offerId"))
+                int offerPrimaryId = resultSet.getInt("id")
                 /*
                 Load customer and project manager info
                  */
-                def customerId =  resultSet.getInt("customerId")
-                def projectManagerId = resultSet.getInt("projectManagerId")
-                def customer = customerGateway.getCustomer(customerId)
-                def projectManager = customerGateway.getProjectManager(projectManagerId)
+                int customerId =  resultSet.getInt("customerId")
+                int projectManagerId = resultSet.getInt("projectManagerId")
+                Customer customer = customerGateway.getCustomer(customerId)
+                ProjectManager projectManager = customerGateway.getProjectManager(projectManagerId)
                 /*
                 Load general offer info
                  */
-                def projectTitle = resultSet.getString("projectTitle")
-                def projectObjective = resultSet.getString("projectObjective")
-                def totalCosts = resultSet.getDouble("totalPrice")
-                def vat = resultSet.getDouble("vat")
-                def overheads = resultSet.getDouble("overheads")
-                def net = resultSet.getDouble("netPrice")
-                def creationDate = resultSet.getDate("creationDate")
-                def expirationDate = resultSet.getDate("expirationDate")
-                def selectedAffiliationId = resultSet.getInt("customerAffiliationId")
-                def selectedAffiliation = customerGateway.getAffiliation(selectedAffiliationId)
-                def items = productGateway.getItemsForOffer(offerPrimaryId)
-                def checksum = resultSet.getString("checksum")
-                def associatedProject = resultSet.getString("associatedProject")
-                def experimentalDesign = resultSet.getString("experimentalDesign")
+                String projectTitle = resultSet.getString("projectTitle")
+                String projectObjective = resultSet.getString("projectObjective")
+                double totalCosts = resultSet.getDouble("totalPrice")
+                double vat = resultSet.getDouble("vat")
+                double overheads = resultSet.getDouble("overheads")
+                double net = resultSet.getDouble("netPrice")
+                Date creationDate = resultSet.getDate("creationDate")
+                Date expirationDate = resultSet.getDate("expirationDate")
+                int selectedAffiliationId = resultSet.getInt("customerAffiliationId")
+                Affiliation selectedAffiliation = customerGateway.getAffiliation(selectedAffiliationId)
+                List<ProductItem> items = productGateway.getItemsForOffer(offerPrimaryId)
+                String checksum = resultSet.getString("checksum")
+                String associatedProject = resultSet.getString("associatedProject")
+                String experimentalDesign = resultSet.getString("experimentalDesign")
 
                 def offerBuilder = new Offer.Builder(
                         customer,

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
@@ -155,10 +155,7 @@ class OfferDbConnector implements CreateOfferDataSource, FetchOfferDataSource, P
         Connection connection = connectionProvider.connect()
         log.info("New offer with id: ${offer.identifier}")
         connection.withCloseable {
-
-            String experimentalDesign = null
-            if(offer.experimentalDesign.isPresent()) experimentalDesign = offer.experimentalDesign.get()
-
+            String experimentalDesign = offer.experimentalDesign.orElse(null)
             PreparedStatement preparedStatement = it.prepareStatement(queryTemplate, Statement.RETURN_GENERATED_KEYS)
             preparedStatement.setString(1, identifier.toString())
             preparedStatement.setDate(2, new Date(offer.modificationDate.time))


### PR DESCRIPTION
addresses #263 

This PR enables TOMATO to parse offers with an experimental design and store such offers in the database  