### PR TITLE
Add experimental design placeholder to offer pdf

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -165,7 +165,7 @@ class OfferToPDFConverter implements OfferExporter {
     private void setProjectInformation() {
         htmlContent.getElementById("project-title").text(offer.projectTitle)
         htmlContent.getElementById("project-description").text(offer.projectDescription)
-        htmlContent.getElementById("experimental-design").text(offer.experimentalDesign.orElse(""))
+        if(offer.experimentalDesign.isPresent()) htmlContent.getElementById("experimental-design").text(offer.experimentalDesign.get())
     }
 
     private void setCustomerInformation() {

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -68,7 +68,7 @@
             </div>
             <br>
             <div id="experimental-design" class="project-content">
-                The experimental design is described here
+                No experimental design has been described.
             </div>
             <br>
             <div>Detailed information about the comprised services can be found <a href="#items-container-table">here</a>.</div>


### PR DESCRIPTION
Adds a placeholder text (No experimental design defined.) to the offer pdf, if no design is specified.