### PR TITLE
Allow date picker reset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Add timeout of 10 second to PDF rendering (`#494 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/494>`_)
 
+* Allow resetting the date picker in the offer overview (`#486 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/486>`_)
 
 **Dependencies**
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/GridUtils.groovy
@@ -79,7 +79,9 @@ class GridUtils {
             Date dateFromLocal = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
             return dateFromLocal == date
         }catch(Exception ignore){
-            return false
+            //if the local date cannot be parsed we want the filter to not be applied and return true for all inputs
+            return true
         }
     }
+
 }


### PR DESCRIPTION
This PR allows resetting the date picker by deleting the date content and obtaining the original list of all offers.
