### PR TITLE
Select first available address addition as default value

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -230,7 +230,7 @@ class CreatePersonView extends VerticalLayout {
         this.addressAdditionComboBox.setDataProvider(dataProvider)
         dataProvider.setSortOrder({it.addressAddition}, SortDirection.ASCENDING)
 
-        addressAdditionComboBox.setSelectedItem(dataProvider.getItems().getAt(0))
+        this.addressAdditionComboBox.setSelectedItem(dataProvider.getItems().getAt(0))
     }
 
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -229,6 +229,8 @@ class CreatePersonView extends VerticalLayout {
         ListDataProvider<Affiliation> dataProvider = organisation.affiliations
         this.addressAdditionComboBox.setDataProvider(dataProvider)
         dataProvider.setSortOrder({it.addressAddition}, SortDirection.ASCENDING)
+
+        addressAdditionComboBox.setSelectedItem(dataProvider.getItems().getAt(0))
     }
 
     /**


### PR DESCRIPTION
**Description of changes**
Fix for issue #492. A simple solution, to auto-select the first option in the address addition combobox after an organization has been chosen.
