### PR TITLE
Fix duplicated productID

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Duplicate product identifiers are no longer generated (`#551 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/551>`_) fixes (`#546 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/546>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -334,7 +334,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
         String id = result.getString(1)
         if(id) {
           long idRunningNumber = Long.parseLong(id.split('_')[1])
-          if(idRunningNumber > latestUniqueId) latestUniqueId = Long.parseLong(id.split('_')[1])
+          if(idRunningNumber > latestUniqueId) latestUniqueId = Long.parseLong(idRunningNumber)
         }
       }
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -334,7 +334,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
         String id = result.getString(1)
         if(id) {
           long idRunningNumber = Long.parseLong(id.split('_')[1])
-          if(idRunningNumber > latestUniqueId) latestUniqueId = Long.parseLong(idRunningNumber)
+          if(idRunningNumber > latestUniqueId) latestUniqueId = idRunningNumber
         }
       }
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/products/ProductsDbConnector.groovy
@@ -318,7 +318,7 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
   }
 
   private Long fetchLatestIdentifier(String productType){
-    String query = "SELECT MAX(productId) FROM product WHERE productId LIKE ?"
+    String query = "SELECT productId FROM product WHERE productId LIKE ?"
     Connection connection = provider.connect()
 
     String category = productType + "_%"
@@ -332,8 +332,10 @@ class ProductsDbConnector implements ArchiveProductDataSource, CreateProductData
 
       while(result.next()){
         String id = result.getString(1)
-
-        if(id) latestUniqueId = Long.parseLong(id.split('_')[1])
+        if(id) {
+          long idRunningNumber = Long.parseLong(id.split('_')[1])
+          if(idRunningNumber > latestUniqueId) latestUniqueId = Long.parseLong(id.split('_')[1])
+        }
       }
     }
 


### PR DESCRIPTION
fixes #546 
The issue was, that the maximal string was searched and not the highest number.