### PR TITLE
Upgrade vaadin:8.12.3 -> 8.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Dependencies**
 
+* ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)
+
+
 **Deprecated**
 
 1.0.0-beta.1 (2021-04-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+uncategorized
+-------------
+**Dependencies**
+
+* ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)
+
+
+
 1.0.0-beta.2
 -------------
 
@@ -16,9 +24,6 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * Rephrased error message for product creation failure (`#552 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/263>`_)
 
 **Dependencies**
-
-* ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)
-
 
 **Deprecated**
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
 		<groovy.version>3.0.8</groovy.version>
 
-		<vaadin.version>8.12.3</vaadin.version>
-		<vaadin.plugin.version>8.12.3</vaadin.plugin.version>
+		<vaadin.version>8.13.0</vaadin.version>
+		<vaadin.plugin.version>8.13.0</vaadin.plugin.version>
 	</properties>
 	<pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
This commit upgrades vaadin from version 8.12.3 to the latest version of framework 8.
The change is necessary to address CVE-2021-31409

Many thanks for contributing to this project!

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.rst` is updated
