### PR TITLE
Continue item enumeration over all productgroups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)
+
 **Dependencies**
 
 * ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -332,13 +332,15 @@ class OfferToPDFConverter implements OfferExporter {
 
     void generateProductTable(Map productItemsMap, int maxTableItems) {
         // Create the items in html in the overview table
+        int itemNumber = 0
         productItemsMap.each {ProductGroups productGroup, List<ProductItem> items ->
             //Check if there are ProductItems stored in map entry
             if(items){
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
                 htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup))
-                items.eachWithIndex {ProductItem item, int itemPos ->
+                items.each{ProductItem item ->
+                    itemNumber++
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
                         ++tableCount
@@ -347,8 +349,7 @@ class OfferToPDFConverter implements OfferExporter {
                         tableItemsCount = 1
                     }
                     //add product to current table
-                    int productNumber = itemPos + 1
-                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(productNumber, item))
+                    htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemNumber, item))
                     tableItemsCount++
                 }
                 //add subtotal footer to table


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
Addresses #562 by continuing the enumeration of the items in the offer pdf across all product groups

**To Test** 
Download an Offer PDF and check the enumeration of the individual items across the productgroups
![continous enumeration](https://user-images.githubusercontent.com/29627977/118256115-6c0c0100-b4ad-11eb-84c9-7afdd0acf823.png)

