### PR TITLE
Introduce filterable Project Manager column to OfferOverview 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Introduce filterable Project Manager column to offer overview (`#576 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/576>`_)
+
 **Fixed**
 
 **Dependencies**
@@ -16,6 +18,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)
 
 **Deprecated**
+
+* Deprecate OfferOverview Constructor to allow for inclusion of ProjectManager (`#576 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/576>`_)
 
 
 1.0.0-beta.2 (2021-04-30)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -138,6 +138,8 @@ class OfferOverviewView extends FormLayout {
                 .setCaption("Project Title").setId("ProjectTitle")
         overviewGrid.addColumn({overview -> overview.getCustomer()})
                 .setCaption("Customer").setId("Customer")
+        overviewGrid.addColumn({overview -> overview.getProjectManager()})
+                .setCaption("ProjectManager").setId("ProjectManager")
         overviewGrid.addColumn({overview ->
             overview.getAssociatedProject().isPresent() ? overview.getAssociatedProject().get() :
                     "-"}).setCaption("Project ID").setId("ProjectID")
@@ -154,20 +156,23 @@ class OfferOverviewView extends FormLayout {
     }
 
     private void setupFilters(ListDataProvider<OfferOverview> offerOverviewDataProvider) {
-        HeaderRow customerFilterRow = overviewGrid.appendHeaderRow()
+        HeaderRow headerFilterRow = overviewGrid.appendHeaderRow()
 
         GridUtils.setupColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("OfferId"),
-                customerFilterRow)
+                headerFilterRow)
         GridUtils.setupColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("ProjectTitle"),
-                customerFilterRow)
+                headerFilterRow)
         GridUtils.setupColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("Customer"),
-                customerFilterRow)
+                headerFilterRow)
+        GridUtils.setupColumnFilter(offerOverviewDataProvider,
+                overviewGrid.getColumn("ProjectManager"),
+                headerFilterRow)
         GridUtils.setupDateColumnFilter(offerOverviewDataProvider,
                 overviewGrid.getColumn("CreationDate"),
-                customerFilterRow)
+                headerFilterRow)
     }
 
     private void setupListeners() {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferDbConnector.groovy
@@ -191,7 +191,7 @@ class OfferDbConnector implements CreateOfferDataSource, FetchOfferDataSource, P
         List<OfferOverview> offerOverviewList = []
 
         String query = "SELECT offerId, creationDate, projectTitle, " +
-                "totalPrice, first_name, last_name, email, associatedProject\n" +
+                "totalPrice, first_name, last_name, email, projectManagerId, associatedProject\n" +
                 "FROM offer \n" +
                 "LEFT JOIN person \n" +
                 "ON offer.customerId = person.id"
@@ -206,10 +206,13 @@ class OfferDbConnector implements CreateOfferDataSource, FetchOfferDataSource, P
                         resultSet.getString("last_name"),
                         resultSet.getString("email"))
                         .build()
+                int projectManagerId = resultSet.getInt("projectManagerId")
+                ProjectManager projectManager = customerGateway.getProjectManager(projectManagerId)
                 def projectTitle = resultSet.getString("projectTitle")
                 def totalCosts = resultSet.getDouble("totalPrice")
                 def creationDate = resultSet.getDate("creationDate")
                 def customerName = "${customer.getFirstName()} ${customer.getLastName()}"
+                def projectManagerName = "${projectManager.getFirstName()} ${projectManager.getLastName()}"
                 def offerId = parseOfferId(resultSet.getString("offerId"))
                 Optional<ProjectIdentifier> projectIdentifier = parseProjectIdentifier(
                         resultSet.getString("associatedProject"))
@@ -218,11 +221,11 @@ class OfferDbConnector implements CreateOfferDataSource, FetchOfferDataSource, P
                 if (projectIdentifier.isPresent()) {
                     offerOverview = new OfferOverview(offerId,
                             creationDate,projectTitle,
-                            customerName, totalCosts, projectIdentifier.get())
+                            customerName, projectManagerName ,totalCosts, projectIdentifier.get())
                 } else {
                     offerOverview = new OfferOverview(offerId,
                             creationDate,projectTitle, "",
-                            customerName, totalCosts)
+                            customerName, projectManagerName, totalCosts)
                 }
                 offerOverviewList.add(offerOverview)
             }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferOverview.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OfferOverview.groovy
@@ -26,6 +26,8 @@ class OfferOverview {
 
     final String customer
 
+    final String projectManager
+
     final Date modificationDate
 
     final double totalPrice
@@ -51,6 +53,7 @@ class OfferOverview {
         this.associatedProject = Optional.empty()
     }
 
+    @Deprecated
     OfferOverview(
             OfferId offerId,
             Date modificationDate,
@@ -63,6 +66,42 @@ class OfferOverview {
         this.projectId = ""
         this.projectTitle = projectTitle
         this.customer = customer
+        this.totalPrice = totalPrice
+        this.associatedProject = Optional.of(associatedProject)
+    }
+
+    OfferOverview(
+            OfferId offerId,
+            Date modificationDate,
+            String projectTitle,
+            String projectId,
+            String customer,
+            String projectManager,
+            double totalPrice) {
+        this.offerId = offerId
+        this.modificationDate = modificationDate
+        this.projectId = projectId
+        this.projectTitle = projectTitle
+        this.customer = customer
+        this.projectManager = projectManager
+        this.totalPrice = totalPrice
+        this.associatedProject = Optional.empty()
+    }
+
+    OfferOverview(
+            OfferId offerId,
+            Date modificationDate,
+            String projectTitle,
+            String customer,
+            String projectManager,
+            double totalPrice,
+            ProjectIdentifier associatedProject) {
+        this.offerId = offerId
+        this.modificationDate = modificationDate
+        this.projectId = ""
+        this.projectTitle = projectTitle
+        this.customer = customer
+        this.projectManager = projectManager
         this.totalPrice = totalPrice
         this.associatedProject = Optional.of(associatedProject)
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OverviewService.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/offers/OverviewService.groovy
@@ -54,6 +54,7 @@ class OverviewService implements ResourcesService<OfferOverview> {
                         affectedOffer.modificationDate,
                         affectedOffer.projectTitle,
                         affectedOffer.customer.toString(),
+                        affectedOffer.projectManager.toString(),
                         affectedOffer.totalPrice,
                         project.projectId)
                 this.addToResource(updatedOverview)
@@ -79,6 +80,7 @@ class OverviewService implements ResourcesService<OfferOverview> {
                 offer.projectTitle,
                 "",
                 "${offer.customer.firstName} ${offer.customer.lastName}",
+                "${offer.projectManager.firstName} ${offer.projectManager.lastName}",
                 offer.totalPrice
         )
     }


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR addresses #576 by introducing the name of the Project Manager associated with an offer as a filterable column to the `OfferOverview` View.
It also includes the necessary changes to the offer overview viewmodel, the database and the associated services. 

**Technical details**
To allow for the inclusion of the Project Manager in the `OfferOverview` viewmodel, i had to deprecate the current `OfferOverview `constructors and introduce new constructor which include the name of the project manager as a string parameter. 
This is necessary since we currently employ 2 seperate constructors for creating an `OfferOverview`, which are distinct only be either needing a `ProjectIdentifier` or an empty string as a parameter.

**Additional context**
Demo here: 
https://user-images.githubusercontent.com/29627977/118267007-b1372f80-b4bb-11eb-9b36-bfb83d374d74.mov


