### PR TITLE
Taxes are also not applicable for customers from abroad

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)
 
-* Taxes for offers outside of germany is set to 0 (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
+* Tax cost for offers outside of germany is set to 0 during offer creation (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
+
+* Tax cost for offers outside of germany is set to 0 in Offer PDF (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
 
 **Dependencies**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)
 
-* Tax cost for offers outside of germany is set to 0 during offer creation (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
-
-* Tax cost for offers outside of germany is set to 0 in Offer PDF (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
+* Tax cost for offers outside of germany is set to 0 (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
 
 **Dependencies**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)
 
+* Taxes for offers outside of germany is set to 0 (`#575 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/575>`_)
+
 **Dependencies**
 
 * ``com.vaadin.vaadin-bom:8.12.3`` -> ``8.13.0`` (`#572 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/572>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -269,7 +269,9 @@ class OfferToPDFConverter implements OfferExporter {
 
     void setTaxationRatioInSummary() {
         DecimalFormat decimalFormat = new DecimalFormat("#%")
-        double taxRatio = determineTaxCost(offer.getSelectedCustomerAffiliation().getCountry(), offer.getSelectedCustomerAffiliation().getCategory())
+        String country = offer.getSelectedCustomerAffiliation().getCountry()
+        AffiliationCategory affiliationCategory = offer.getSelectedCustomerAffiliation().getCategory()
+        double taxRatio = determineTaxCost(country, affiliationCategory)
         String taxPercentage = decimalFormat.format(taxRatio)
         htmlContent.getElementById("total-taxes-ratio").text("VAT (${taxPercentage})")
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -263,7 +263,6 @@ class OfferToPDFConverter implements OfferExporter {
     void setTaxationStatement() {
         if(!offer.getSelectedCustomerAffiliation().country.equals(countryWithVAT)) {
             htmlContent.getElementById("vat-cost-applicable").text("Taxation is not applied to offers outside of ${countryWithVAT}")
-            htmlContent.getElementById("total-taxes-ratio").text("VAT (0%)")
         }
 
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -269,15 +269,17 @@ class OfferToPDFConverter implements OfferExporter {
 
     void setTaxationRatioInSummary() {
         DecimalFormat decimalFormat = new DecimalFormat("#%")
-        double taxRatio
-        if(offer.getSelectedCustomerAffiliation().getCountry().equals(countryWithVAT) && !offer.getSelectedCustomerAffiliation().getCategory().equals(noVatCategory)) {
-            taxRatio = VAT
-        }
-        else {
-            taxRatio = 0
-        }
+        double taxRatio = determineTaxCost(offer.getSelectedCustomerAffiliation().getCountry(), offer.getSelectedCustomerAffiliation().getCategory())
         String taxPercentage = decimalFormat.format(taxRatio)
         htmlContent.getElementById("total-taxes-ratio").text("VAT (${taxPercentage})")
+    }
+
+    // Apply VAT only if the offer originated from Germany and it's affilation category is non-internal
+    static double determineTaxCost(String country, AffiliationCategory category) {
+        if(country.equals(countryWithVAT) && !category.equals(noVatCategory)) {
+            return VAT
+        }
+            return 0
     }
 
     void setSubTotalPrices(ProductGroups productGroup, List<ProductItem> productItems) {
@@ -523,15 +525,7 @@ class OfferToPDFConverter implements OfferExporter {
 
             DecimalFormat decimalFormat = new DecimalFormat("#%")
             String overheadPercentage = decimalFormat.format(overheadRatio)
-            double taxRatio
-            //Apply Vat only if the offer originated from germany and if it's a non-internal Affilation
-            if (affiliation.getCountry().equals(countryWithVAT) && !affiliation.getCategory().equals(noVatCategory)){
-                taxRatio = VAT
-            }
-            else
-            {
-                taxRatio = 0
-            }
+            double taxRatio = determineTaxCost(affiliation.country, affiliation.getCategory())
             String taxPercentage = decimalFormat.format(taxRatio)
 
             return """<div id="grid-table-footer">

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -234,11 +234,11 @@ class OfferToPDFConverter implements OfferExporter {
             String elementId = "product-items" + "-" + tableCount
             htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
             htmlContent.getElementById("item-table-grid")
-                    .append(ItemPrintout.tableFooter(offer.overheadRatio))
+                    .append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation().country))
         } else {
             //otherwise add total pricing to table
             htmlContent.getElementById("item-table-grid")
-                    .append(ItemPrintout.tableFooter(offer.overheadRatio))
+                    .append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation().country))
         }
     }
 
@@ -474,10 +474,20 @@ class OfferToPDFConverter implements OfferExporter {
                                  """
         }
 
-        static String tableFooter(double overheadRatio){
+        static String tableFooter(double overheadRatio, String country){
 
             DecimalFormat decimalFormat = new DecimalFormat("#%")
             String overheadPercentage = decimalFormat.format(overheadRatio)
+            double taxRatio
+            if (country.equals("Germany")){
+                taxRatio = 0.19
+            }
+            else
+            {
+                taxRatio = 0
+            }
+
+            String taxPercentage = decimalFormat.format(taxRatio)
 
             return """<div id="grid-table-footer">
                                      <div class="row total-costs" id = "offer-net">
@@ -490,7 +500,7 @@ class OfferToPDFConverter implements OfferExporter {
                                          <div class="col-2 price-value" id="overhead-cost-value"></div>
                                      </div>
                                      <div class="row total-costs" id = "offer-vat">
-                                         <div class="col-10 cost-summary-field">VAT (19%):</div>
+                                         <div class="col-10 cost-summary-field">VAT (${taxPercentage}):</div>
                                          <div class="col-2 price-value" id="vat-cost-value">0.00</div>
                                      </div>
                                      <div class="row total-costs" id ="offer-total">

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -281,7 +281,7 @@ class OfferToPDFConverter implements OfferExporter {
         if(country.equals(countryWithVAT) && !category.equals(noVatCategory)) {
             return VAT
         }
-            return 0
+        return 0
     }
 
     void setSubTotalPrices(ProductGroups productGroup, List<ProductItem> productItems) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -262,7 +262,7 @@ class OfferToPDFConverter implements OfferExporter {
 
     void setTaxationStatement() {
         if(!offer.getSelectedCustomerAffiliation().country.equals(countryWithVAT)) {
-            htmlContent.getElementById("vat-cost-applicable").text("Vat is non-applicable for offers outside of ${countryWithVAT}")
+            htmlContent.getElementById("vat-cost-applicable").text("Taxation is not applied to offers outside of ${countryWithVAT}")
             htmlContent.getElementById("total-taxes-ratio").text("VAT (0%)")
         }
 

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -72,8 +72,9 @@
             </div>
             <br>
             <div>Detailed information about the comprised services are listed in the <a href="#items-container-table">Quotation Details</a>.</div>
-
             <div class="cost-summary">
+                <div id = "vat-cost-applicable"></div>
+                <br>
                 <div class="">Estimated total (net)</div>
                 <div id ="total-costs-net">1,000.00 €</div>
             </div>

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -298,12 +298,13 @@ class Offer {
     /**
      * The tax price on all items net price including overheads.
      *
-     * For internal persons, this will be 0.
+     * For internal persons and customers outside of Germany, this will be set to 0.
+     *
      *
      * @return The amount of VAT price based on all items in the offer.
      */
     double getTaxCosts() {
-        if (selectedCustomerAffiliation.category.equals(AffiliationCategory.INTERNAL)) {
+        if (selectedCustomerAffiliation.category.equals(AffiliationCategory.INTERNAL) || !selectedCustomerAffiliation.country.equals("Germany")) {
             return 0
         }
         return (calculateNetPrice() + getOverheadSum()) * VAT

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -300,7 +300,6 @@ class Offer {
      *
      * For internal persons and customers outside of Germany, this will be set to 0.
      *
-     *
      * @return The amount of VAT price based on all items in the offer.
      */
     double getTaxCosts() {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -108,6 +108,16 @@ class Offer {
     private static final double VAT = 0.19
 
     /**
+     * Holds the Country for which VAT is applicable
+     */
+    private static final String countryWithVat = "Germany"
+
+    /**
+     * Holds the AffiliationCategory for which VAT is non-applicable
+     */
+    private static final AffiliationCategory noVatCategory = AffiliationCategory.INTERNAL
+
+    /**
      * A project that has been created from this offer (optional)
      */
     private Optional<ProjectIdentifier> associatedProject
@@ -298,15 +308,17 @@ class Offer {
     /**
      * The tax price on all items net price including overheads.
      *
-     * For internal persons and customers outside of Germany, this will be set to 0.
+     * For internal affiliated customers and customers outside of Germany, this will be set to 0.
      *
      * @return The amount of VAT price based on all items in the offer.
      */
     double getTaxCosts() {
-        if (selectedCustomerAffiliation.category.equals(AffiliationCategory.INTERNAL) || !selectedCustomerAffiliation.country.equals("Germany")) {
+        if (!selectedCustomerAffiliation.category.equals(noVatCategory) && selectedCustomerAffiliation.country.equals(countryWithVat)) {
+            return (calculateNetPrice() + getOverheadSum()) * VAT
+        }
+        else {
             return 0
         }
-        return (calculateNetPrice() + getOverheadSum()) * VAT
     }
 
     /**

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
@@ -84,7 +84,7 @@ class CreateOfferSpec extends Specification {
         1* output.createdNewOffer(_)
     }
 
-    def "Taxes and overhead cost for internal affilations are set to 0"(){
+    def "calculate offer price for internal affiliations correctly"(){
         given:
         CreateOfferOutput output = Mock(CreateOfferOutput)
         CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
@@ -84,7 +84,7 @@ class CreateOfferSpec extends Specification {
         1* output.createdNewOffer(_)
     }
 
-    def "calculate offer price correctly"(){
+    def "Taxes and overhead cost for internal affilations are set to 0"(){
         given:
         CreateOfferOutput output = Mock(CreateOfferOutput)
         CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)
@@ -99,6 +99,23 @@ class CreateOfferSpec extends Specification {
         then:
         1 * output.calculatedPrice(2.8, 0, 0, 2.8)
     }
+
+    def "Taxes for Affilations outside of Germany are set to 0"(){
+        given:
+        CreateOfferOutput output = Mock(CreateOfferOutput)
+        CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)
+
+        and:
+        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, ProductUnit.PER_SAMPLE, "1")),
+                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, ProductUnit.PER_SAMPLE, "1"))]
+        when:
+        createOffer.calculatePrice(items, new Affiliation.Builder("Test", "", "", "").country("France")
+                .category(AffiliationCategory.EXTERNAL).build())
+
+        then:
+        1 * output.calculatedPrice(8.0, 0, 3.2, 11.2)
+    }
+
 
     def "Creating an Offer DTO from the Offer Entity works correctly"() {
         given:


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
Addresses #575 by checking if the country of an affiliation associated with an Offer is set to "Germany" during offer Creation/Update. 
If that is not the case the taxation amount of the offer is set to 0.
This is also done in the Offer PDF printout and an additional statement indicating this change is added to the first page of the pdf. 

**Technical Details** 
The VAT Taxation rate is only applied if the `AffiliationCategory` of the Offer Affiliation is set to a enum value that differs from `INTERNAL` and the Affiliation `Country` property is set to "Germany". 
Also this PR doesn't change the values associated with offers already stored in the database. 

**Additional context**
Currently the statement "Vat is non-applicable for offers outside of Germany" is printed on the first page of the offer when the customer is from outside of Germany, since it was not specified where it should be printed in the issue. 
**Demo here:** 
https://user-images.githubusercontent.com/29627977/118661907-dd222000-b7ef-11eb-99a9-e3bce9a147c6.mov


