### PR TITLE
Include Overhead Ratio and Price in overview on first page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,9 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Introduce filterable Project Manager column to offer overview (`#576 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/576>`_)
 
-* Displays a total price overview on the first offer page, including taxes and overheads
+* Displays a total price overview on the first offer page, including taxes, net cost and total cost (`#559 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/559>`_)
+
+* Include overhead cost in total price overview on the first offer page (`#593 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/593>`_)
 
 * Add a column filter option which takes a predicate as argument (`#589 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/589>`_)
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -270,7 +270,7 @@ class OfferToPDFConverter implements OfferExporter {
 
         // First page summary
         htmlContent.getElementById("total-costs-net").text(netPriceWithSymbol)
-        htmlContent.getElementById("ratio-costs-overhead").text("Overhead (${overheadPercentage})")
+        htmlContent.getElementById("ratio-costs-overhead").text("Overheads (${overheadPercentage})")
         htmlContent.getElementById("total-costs-overhead").text(overheadPrice)
         htmlContent.getElementById("total-taxes").text(taxesWithCurrency)
         htmlContent.getElementById("total-costs-sum").text(totalPriceWithCurrency)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -264,10 +264,14 @@ class OfferToPDFConverter implements OfferExporter {
         final taxesWithCurrency = Currency.getFormatterWithSymbol().format(offer.taxes)
         final netPrice = Currency.getFormatterWithoutSymbol().format(offer.netPrice)
         final netPriceWithSymbol = Currency.getFormatterWithSymbol().format(offer.netPrice)
-        final overheadPrice = Currency.getFormatterWithoutSymbol().format(offer.overheads)
+        final overheadPrice = Currency.getFormatterWithSymbol().format(offer.overheads)
+        DecimalFormat decimalFormat = new DecimalFormat("#%")
+        String overheadPercentage = decimalFormat.format(offer.overheadRatio)
 
         // First page summary
         htmlContent.getElementById("total-costs-net").text(netPriceWithSymbol)
+        htmlContent.getElementById("ratio-costs-overhead").text("Overhead (${overheadPercentage})")
+        htmlContent.getElementById("total-costs-overhead").text(overheadPrice)
         htmlContent.getElementById("total-taxes").text(taxesWithCurrency)
         htmlContent.getElementById("total-costs-sum").text(totalPriceWithCurrency)
 

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -82,7 +82,7 @@
                         <td class="table-row">Net</td>
                         <td id ="total-costs-net" class="right-align table-row">€ 1,000.00</td>
                     </tr>
-                        <td class="table-row" id="ratio-costs-overhead">Overhead (0%)</td>
+                        <td class="table-row" id="ratio-costs-overhead">Overheads (0%)</td>
                         <td id ="total-costs-overhead" class="right-align table-row">€ 190.00</td>
                     </tr>
                     <tr style="border-bottom: 1px solid black;">

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -82,6 +82,9 @@
                         <td class="table-row">Net</td>
                         <td id ="total-costs-net" class="right-align table-row">€ 1,000.00</td>
                     </tr>
+                        <td class="table-row" id="ratio-costs-overhead">Overhead (0%)</td>
+                        <td id ="total-costs-overhead" class="right-align table-row">€ 190.00</td>
+                    </tr>
                     <tr style="border-bottom: 1px solid black;">
                         <td class="table-row">VAT (19%)</td>
                         <td id ="total-taxes" class="right-align table-row">€ 190.00</td>


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
Addresses #592 by introducing the overhead cost and ratio rows to the summary table on the first page in the offer pdf. 
The values of which are dynamically determined from the offer DTO. 

**Additional context**
Example Screenshot: 
![OverheadCost](https://user-images.githubusercontent.com/29627977/118669631-32f9c680-b7f6-11eb-8567-90aaef60cbde.png)

