### PR TITLE
Enable Github workflow for changelog update checks

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dangoslen/changelog-enforcer@v2
         with:
-          changeLogPath: 'CHANGELOG.md'
+          changeLogPath: 'CHANGELOG.rst'
           skipLabels: 'Skip-Changelog'

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -1,0 +1,15 @@
+name: "Changelog update"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v2
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'Skip-Changelog'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Add a column filter option which takes a predicate as argument (`#589 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/589>`_)
 
+* Enable Github workflow for changelog update checks (`#595 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/595>`_)
+
 **Fixed**
 
 * Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)


### PR DESCRIPTION
This PR introduces a Github workflow that checks, if the changelog has been updated in the target branch compared to the based branch.

The workflow should fail, until the changelog has been updated.