### PR TITLE
Move table header below category titles in productitem tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Enable sorting products by productId (MaintainProductView) (`#574 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/574>`_)
 
+* Move table header below section/product category title in offer html template (`#604 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/604>`_)
+
 **Fixed**
 
 * Enumeration of product items increases over all productGroups in Offer PDF (`#562 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/562>`_)

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -141,29 +141,29 @@
 
         <div class="items-overview common-text" id="items-container-table">
             <div class="grid-container-table" id="item-table-grid">
-                <div class="row table-header" id="grid-table-header-1">
-                    <div class="col-1">
-                        &#8470;
-                    </div>
-                    <div class="col-4">
-                        Service Description
-                    </div>
-                    <div class="col-1 price-value">
-                        Amount
-                    </div>
-                    <div class="col-2 text-center">
-                        Unit
-                    </div>
-                    <div class="col-2 price-value">
-                        Price/Unit (€)
-                    </div>
-                    <div class="col-2 price-value">
-                        Total (€)
-                    </div>
-                </div>
                 <div class="product-items" id="product-items-1">
                     <div class="small-spacer"></div>
                     <h4>Data generation (DG)</h4>
+                    <div class="row table-header" id="grid-table-header-1">
+                        <div class="col-1">
+                            &#8470;
+                        </div>
+                        <div class="col-4">
+                            Service Description
+                        </div>
+                        <div class="col-1 price-value">
+                            Amount
+                        </div>
+                        <div class="col-2 text-center">
+                            Unit
+                        </div>
+                        <div class="col-2 price-value">
+                            Price/Unit (€)
+                        </div>
+                        <div class="col-2 price-value">
+                            Total (€)
+                        </div>
+                    </div>
                     <div class="row product-item">
                         <div class="col-1">
                             1
@@ -365,6 +365,26 @@
                         </div>
                     </div>
                     <h4>Data analysis (DA)</h4>
+                    <div class="row table-header" id="grid-table-header-2">
+                        <div class="col-1">
+                            &#8470;
+                        </div>
+                        <div class="col-4">
+                            Service Description
+                        </div>
+                        <div class="col-1 price-value">
+                            Amount
+                        </div>
+                        <div class="col-2 text-center">
+                            Unit
+                        </div>
+                        <div class="col-2 price-value">
+                            Price/Unit (€)
+                        </div>
+                        <div class="col-2 price-value">
+                            Total (€)
+                        </div>
+                    </div>
                     <div class="row product-item">
                         <div class="col-1">
                             8
@@ -405,29 +425,29 @@
                     </div>
                 </div>
                 <div class="pagebreak"></div>
-                <div class="row table-header" id="grid-table-header-2">
-                    <div class="col-1">
-                        &#8470;
-                    </div>
-                    <div class="col-4">
-                        Service Description
-                    </div>
-                    <div class="col-1 price-value">
-                        Amount
-                    </div>
-                    <div class="col-2 text-center">
-                        Unit
-                    </div>
-                    <div class="col-2 price-value">
-                        Price/Unit (€)
-                    </div>
-                    <div class="col-2 price-value">
-                        Total (€)
-                    </div>
-                </div>
                 <div class="product-items" id="product-items-2">
                     <div class="small-spacer"></div>
                     <h4>Project management and data storage (PM and DS)</h4>
+                    <div class="row table-header" id="grid-table-header-3">
+                        <div class="col-1">
+                            &#8470;
+                        </div>
+                        <div class="col-4">
+                            Service Description
+                        </div>
+                        <div class="col-1 price-value">
+                            Amount
+                        </div>
+                        <div class="col-2 text-center">
+                            Unit
+                        </div>
+                        <div class="col-2 price-value">
+                            Price/Unit (€)
+                        </div>
+                        <div class="col-2 price-value">
+                            Total (€)
+                        </div>
+                    </div>
                     <div class="row product-item">
                         <div class="col-1">
                             9


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR moves the table header below the section/product category titles in the the Offer html template 

**Technical details**
Note that this doesn't change anything in the dynamically created offer pdf. 
![Example2](https://user-images.githubusercontent.com/29627977/119100912-b72b9400-ba18-11eb-8d4c-adb3d7a310f0.png)
![Example1](https://user-images.githubusercontent.com/29627977/119100908-b72b9400-ba18-11eb-83ce-b9f1d67fa58c.png)