### PR TITLE
Set user_id to emailaddress of person in database during person creation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* user_id of a person is set in database during person creation/update (`#616 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/616>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/PersonDbConnector.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/PersonDbConnector.groovy
@@ -225,18 +225,19 @@ class PersonDbConnector implements CreatePersonDataSource, SearchPersonDataSourc
   }
   
   private static int createNewPerson(Connection connection, Person person) {
-    String query = "INSERT INTO person (first_name, last_name, title, email, active) " +
-            "VALUES(?, ?, ?, ?, ?)"
+    String query = "INSERT INTO person (user_id, first_name, last_name, title, email, active) " +
+            "VALUES(?, ?, ?, ?, ?, ?)"
 
     List<Integer> generatedKeys = []
 
     def statement = connection.prepareStatement(query, Statement.RETURN_GENERATED_KEYS)
-    statement.setString(1, person.firstName )
-    statement.setString(2, person.lastName)
-    statement.setString(3, person.title.value)
-    statement.setString(4, person.emailAddress )
+    statement.setString(1, person.emailAddress)
+    statement.setString(2, person.firstName)
+    statement.setString(3, person.lastName)
+    statement.setString(4, person.title.value)
+    statement.setString(5, person.emailAddress)
     //a new customer is always active
-    statement.setBoolean(5, true)
+    statement.setBoolean(6, true)
     statement.execute()
     def keys = statement.getGeneratedKeys()
     while (keys.next()){


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
Addresses #616 by adding the persons email address to the `user_id` column in the `person` table in the userdb during person creation/update. 