### PR TITLE
Fix Spacing of total-cost row in cost summary table of generated offer pdf 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * user_id of a person is set in database during person creation/update (`#616 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/616>`_)
 
+* layout of total price row in price summary of offer pdf stays inline (`#615 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/615>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/resources/offer-template/stylesheet.css
+++ b/offer-manager-app/src/main/resources/offer-template/stylesheet.css
@@ -126,6 +126,7 @@ h2 {
 
 .total-costs-sum-row {
   font-weight: bold;
+  white-space:nowrap;
 }
 
 .signature {


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
Addresses #615 by explicitly setting the whitspace css management in the total cost summary row element.

![no wrap](https://user-images.githubusercontent.com/29627977/119659668-af139000-be2e-11eb-893b-eb880d4c82a4.png)

**How to Test**
Compare the generated PDF of an Offer with a high total cost column(e.g. Offer ID `O_friedrich_tpeq_1`) on the development branch with the same offer but generated via this branch. 