### PR TITLE
Implement layout changes in offer PDF 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Adapt dynamically generated offer PDF layout to match html template(`#613 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/613>`_)
+
 **Fixed**
 
 * user_id of a person is set in database during person creation/update (`#616 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/616>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -40,9 +40,9 @@ class OfferToPDFConverter implements OfferExporter {
     static final CHROMIUM_EXECUTABLE = "CHROMIUM_EXECUTABLE"
 
     /**
-     * Variable used to count the number of productItems in a productTable
+     * Variable used to count the number of Items added to a page
      */
-    private static int tableItemsCount
+    private static int pageItemsCount
 
     /**
      * Variable used to count the number of generated productTables in the Offer PDF
@@ -243,7 +243,7 @@ class OfferToPDFConverter implements OfferExporter {
         generateProductTable(productItemsMap, maxTableItems)
         //Append total cost footer
         String elementId = "product-items" + "-" + tableCount
-        if (tableItemsCount > maxTableItems) {
+        if (pageItemsCount > maxTableItems) {
             //If currentTable is filled with Items generate new one and add total pricing there
             ++tableCount
             htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
@@ -372,32 +372,32 @@ class OfferToPDFConverter implements OfferExporter {
             //Check if there are ProductItems stored in map entry
             if(items){
                 //Each Title will take spacing in the generated table
-                tableItemsCount++
+                pageItemsCount++
                 def elementId = "product-items" + "-" + tableCount
-                if (tableItemsCount > maxTableItems) {
+                if (pageItemsCount > maxTableItems) {
                     //Start new table on next page
                     ++tableCount
                     htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
                     elementId = "product-items" + "-" + tableCount
                     htmlContent.getElementById("item-table-grid").append(ItemPrintout.createNewTable(elementId))
-                    tableItemsCount = 1
+                    pageItemsCount = 1
                 }
                 //Append Table Title and Header
                 htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup))
                 htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
                 items.each{ProductItem item ->
                     itemNumber++
-                    if (tableItemsCount > maxTableItems) {
+                    if (pageItemsCount > maxTableItems) {
                         ++tableCount
                         htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
                         elementId = "product-items" + "-" + tableCount
                         htmlContent.getElementById("item-table-grid").append(ItemPrintout.createNewTable(elementId))
                         htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
-                        tableItemsCount = 1
+                        pageItemsCount = 1
                     }
                     //add product to current table
                     htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemNumber, item))
-                    tableItemsCount++
+                    pageItemsCount++
                 }
                 //add subtotal footer to table
                 htmlContent.getElementById(elementId).append(ItemPrintout.subTableFooter(productGroup))
@@ -505,7 +505,7 @@ class OfferToPDFConverter implements OfferExporter {
 
         static String subTableFooter(ProductGroups productGroup){
             //Each footer takes up spacing in the current table
-            tableItemsCount++
+            pageItemsCount++
             String footerTitle = productGroup.getAcronym()
             return """<div id="grid-sub-total-footer-${tableCount}" class="grid-sub-total-footer">
                                       <div class="col-6"></div> 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -569,7 +569,7 @@ class OfferToPDFConverter implements OfferExporter {
                                         <div class="col-10 cost-summary-field">
                                             Total:
                                         </div>
-                                        <div class="col-2 price-value" id="final-cost-value">
+                                        <div class="col-2 price-value highlight" id="final-cost-value">
                                             0.00
                                         </div>
                                      </div>

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -223,7 +223,6 @@ class OfferToPDFConverter implements OfferExporter {
         htmlContent.getElementById("product-items-1").empty()
         htmlContent.getElementById("product-items-2").empty()
         // To also remove the styling of the div elements they have to be removed
-        htmlContent.getElementById("grid-table-footer").empty()
         htmlContent.getElementById("template-page-break").remove()
 
         List<ProductItem> productItems = offer.items
@@ -252,7 +251,8 @@ class OfferToPDFConverter implements OfferExporter {
             htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
         }
             //Add total pricing information to grid-table-footer div in template
-            Element element = htmlContent.getElementById("grid-table-footer").append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation()))
+
+            Element element = htmlContent.getElementById("grid-table-footer")
             //Move template footer div after item-table-grid
             htmlContent.getElementById("item-table-grid").after(element)
     }
@@ -312,11 +312,17 @@ class OfferToPDFConverter implements OfferExporter {
         final taxesPrice = Currency.getFormatterWithoutSymbol().format(offer.taxes)
         final totalPrice = Currency.getFormatterWithoutSymbol().format(offer.totalPrice)
 
+        double taxRatio = determineTaxCost(offer.getSelectedCustomerAffiliation().country, offer.getSelectedCustomerAffiliation().getCategory())
+        String taxPercentage = decimalFormat.format(taxRatio)
+
         // Detailed listing summary
+        htmlContent.getElementById("overhead-percentage-value").text("Overheads (${overheadPercentage})")
+        htmlContent.getElementById("vat-percentage-value").text("VAT (${taxPercentage})")
         htmlContent.getElementById("overhead-cost-value").text(overheadPrice)
         htmlContent.getElementById("total-cost-value-net").text(netPrice)
         htmlContent.getElementById("vat-cost-value").text(taxesPrice)
         htmlContent.getElementById("final-cost-value").text(totalPrice)
+
     }
 
     void setQuotationDetails() {
@@ -516,65 +522,5 @@ class OfferToPDFConverter implements OfferExporter {
                                  </div>
                                  """
         }
-
-        static String tableFooter(double overheadRatio, Affiliation affiliation){
-            DecimalFormat decimalFormat = new DecimalFormat("#%")
-            String overheadPercentage = decimalFormat.format(overheadRatio)
-            double taxRatio = determineTaxCost(affiliation.country, affiliation.getCategory())
-            String taxPercentage = decimalFormat.format(taxRatio)
-
-            return """<div class="col-10 cost-summary-field">Overheads (${overheadPercentage})</div>
-                                     <div class="row sub-total-costs" id="DATA_GENERATION-sub-overhead">
-                                        <div class="col-10 cost-summary-field">
-                                            Data Generation:
-                                        </div>
-                                        <div class="col-2 price-value" id="DATA_GENERATION-overhead-costs-value">
-                                            0.00
-                                        </div>
-                                     </div>
-                                     <div class="row sub-total-costs" id="DATA_ANALYSIS-sub-overhead">
-                                        <div class="col-10 cost-summary-field">
-                                            Data Analysis:
-                                        </div>
-                                        <div class="col-2 price-value" id="DATA_ANALYSIS-overhead-costs-value">
-                                            0.00
-                                        </div>
-                                     </div>
-                                     <div class="row total-costs single-overscore" id = "offer-overhead">
-                                        <div class="col-10 cost-summary-field">
-                                            Overhead total:
-                                        </div>
-                                        <div class="col-2 price-value" id="overhead-cost-value">
-                                            0.00
-                                        </div>
-                                     </div>
-                                     <div class="row total-costs" id = "offer-net">
-                                        <div class="col-6"></div>
-                                        <div class="col-4 cost-summary-field">
-                                            Net:
-                                        </div>
-                                        <div class="col-2 price-value" id="total-cost-value-net">
-                                            0.00
-                                        </div>
-                                     </div>
-                                     <div class="row total-costs" id = "offer-vat">
-                                        <div class="col-10 cost-summary-field">
-                                            VAT (${taxPercentage}):
-                                        </div>
-                                        <div class="col-2 price-value" id="vat-cost-value">
-                                            0.00
-                                        </div>
-                                     </div>
-                                     <div class="row total-costs single-overscore" id ="offer-total">
-                                        <div class="col-10 cost-summary-field">
-                                            Total:
-                                        </div>
-                                        <div class="col-2 price-value highlight" id="final-cost-value">
-                                            0.00
-                                        </div>
-                                     </div>
-                                 """
-        }
-
-        }
+    }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -227,6 +227,7 @@ class OfferToPDFConverter implements OfferExporter {
     void setSelectedItems() {
         // Let's clear the existing item template content first
         htmlContent.getElementById("product-items-1").empty()
+        htmlContent.getElementById("product-items-2").empty()
         //and remove the footer on the first page
         //htmlContent.getElementById("grid-table-footer").remove()
 
@@ -250,7 +251,7 @@ class OfferToPDFConverter implements OfferExporter {
             //If currentTable is filled with Items generate new one and add total pricing there
             ++tableCount
             String elementId = "product-items" + "-" + tableCount
-            htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
+            htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader())
             htmlContent.getElementById("item-table-grid")
                     .append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation()))
         } else {
@@ -392,13 +393,14 @@ class OfferToPDFConverter implements OfferExporter {
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
                 htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup))
+                htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
                 items.each{ProductItem item ->
                     itemNumber++
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
                         ++tableCount
                         elementId = "product-items" + "-" + tableCount
-                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
+                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader())
                         tableItemsCount = 1
                     }
                     //add product to current table
@@ -411,7 +413,7 @@ class OfferToPDFConverter implements OfferExporter {
                  should be accounted for the subtotal Footer */
                 int productSpaceCount = 2
 
-                tableItemsCount = tableItemsCount + productSpaceCount
+                tableItemsCount += tableItemsCount + productSpaceCount
                 // Update Footer Prices
                 setSubTotalPrices(productGroup, items)
             }
@@ -479,20 +481,17 @@ class OfferToPDFConverter implements OfferExporter {
 
         }
 
-        static String tableHeader(String elementId) {
-            //1. add pagebreak
+        static String tableHeader() {
             //2. create empty table for elementId
-            return """<div class="pagebreak"></div>
-                                     <div class="row table-header" id="grid-table-header">
-                                         <div class="col-1">Pos.</div>
+            return """<div class="row table-header" id="grid-table-header-${tableCount}">
+                                         <div class="col-1">&#8470;</div>
                                          <div class="col-4">Service Description</div>
                                          <div class="col-1 price-value">Amount</div>
                                          <div class="col-2 text-center">Unit</div>
                                          <div class="col-2 price-value">Price/Unit (€)</div>
                                          <div class="col-2 price-value">Total (€)</div>
                                     </div>
-                                 <div class="product-items" id="${elementId}"></div>
-                             """
+                                    """
         }
 
         static String tableTitle(ProductGroups productGroup){

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -245,8 +245,7 @@ class OfferToPDFConverter implements OfferExporter {
 
        
         tableItemsCount = 1
-        //The maximum Items is currently set manually and estimated by eye,
-        //since there is no way to properly account for differences of lengths of the productItem description
+        //The maximum number of items per page
         int maxTableItems = 13
 
         //Group ProductItems into Data Generation Data Analysis and Data & Project Management Categories

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -243,7 +243,7 @@ class OfferToPDFConverter implements OfferExporter {
         //Initialize Number of table
         tableCount = 1
 
-        //Initialize Count which will be used to determine how many Items are stored in the table
+       
         tableItemsCount = 1
         //The maximum Items is currently set manually and estimated by eye,
         //since there is no way to properly account for differences of lengths of the productItem description

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -111,7 +111,7 @@ class OfferToPDFConverter implements OfferExporter {
         }
 
         String getName() {
-            return this.name;
+            return this.name
         }
 
         String getAcronym() {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -233,16 +233,16 @@ class OfferToPDFConverter implements OfferExporter {
 
         pageItemsCount = 1
         //The maximum number of items per page
-        int maxTableItems = 13
+        int maxPageItems = 13
 
         //Group ProductItems into Data Generation Data Analysis and Data & Project Management Categories
         Map productItemsMap = groupItems(productItems)
 
         //Generate Product Table for each Category
-        generateProductTable(productItemsMap, maxTableItems)
+        generateProductTable(productItemsMap, maxPageItems)
         //Append total cost footer
         String elementId = "product-items" + "-" + tableCount
-        if (pageItemsCount > maxTableItems) {
+        if (pageItemsCount > maxPageItems) {
             //If currentTable is filled with Items generate new one and add total pricing there
             ++tableCount
             htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -253,7 +253,7 @@ class OfferToPDFConverter implements OfferExporter {
         }
             //Add total pricing information to grid-table-footer div in template
             Element element = htmlContent.getElementById("grid-table-footer").append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation()))
-            //Move template div after item-table-grid
+            //Move template footer div after item-table-grid
             htmlContent.getElementById("item-table-grid").after(element)
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -398,7 +398,6 @@ class OfferToPDFConverter implements OfferExporter {
                 items.each{ProductItem item ->
                     itemNumber++
                     if (tableItemsCount > maxTableItems) {
-                        //Start new table on next page if maxTableItems are reached
                         ++tableCount
                         htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
                         elementId = "product-items" + "-" + tableCount

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -233,7 +233,7 @@ class OfferToPDFConverter implements OfferExporter {
         // Let's clear the existing item template content first
         htmlContent.getElementById("product-items-1").empty()
         htmlContent.getElementById("product-items-2").empty()
-        // To also remove the styling of the div elements they have to be removed
+        //We also need to remove the page break between the tables in the template
         htmlContent.getElementById("template-page-break").remove()
 
         //Initialize Number of table

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -251,7 +251,7 @@ class OfferToPDFConverter implements OfferExporter {
             //If currentTable is filled with Items generate new one and add total pricing there
             ++tableCount
             String elementId = "product-items" + "-" + tableCount
-            htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader())
+            htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
             htmlContent.getElementById("item-table-grid")
                     .append(ItemPrintout.tableFooter(offer.overheadRatio, offer.getSelectedCustomerAffiliation()))
         } else {
@@ -393,14 +393,14 @@ class OfferToPDFConverter implements OfferExporter {
                 def elementId = "product-items" + "-" + tableCount
                 //Append Table Title
                 htmlContent.getElementById(elementId).append(ItemPrintout.tableTitle(productGroup))
-                htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
+                htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader(elementId))
                 items.each{ProductItem item ->
                     itemNumber++
                     //start (next) table and add Product to it
                     if (tableItemsCount >= maxTableItems) {
                         ++tableCount
                         elementId = "product-items" + "-" + tableCount
-                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader())
+                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.tableHeader(elementId))
                         tableItemsCount = 1
                     }
                     //add product to current table
@@ -481,7 +481,7 @@ class OfferToPDFConverter implements OfferExporter {
 
         }
 
-        static String tableHeader() {
+        static String tableHeader(String elementId) {
             //2. create empty table for elementId
             return """<div class="row table-header" id="grid-table-header-${tableCount}">
                                          <div class="col-1">&#8470;</div>
@@ -491,6 +491,7 @@ class OfferToPDFConverter implements OfferExporter {
                                          <div class="col-2 price-value">Price/Unit (€)</div>
                                          <div class="col-2 price-value">Total (€)</div>
                                     </div>
+                                    <div class="product-items" id="${elementId}"></div>
                                     """
         }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -332,7 +332,7 @@ class OfferToPDFConverter implements OfferExporter {
         htmlContent.getElementById("overhead-cost-value").text(overheadPrice)
         //Set vat, net and total cost value
         htmlContent.getElementById("total-cost-value-net").text(netPrice)
-        htmlContent.getElementById("vat-percentage-value").text("VAT (${taxPercentage})")
+        htmlContent.getElementById("vat-percentage-value").text("VAT (${taxPercentage}):")
         htmlContent.getElementById("vat-cost-value").text(taxesPrice)
         htmlContent.getElementById("final-cost-value").text(totalPrice)
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -261,7 +261,7 @@ class OfferToPDFConverter implements OfferExporter {
             ++tableCount
             htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
             elementId = "product-items" + "-" + tableCount
-            htmlContent.getElementById("item-table-grid").append(ItemPrintout.seedNewTable(elementId))
+            htmlContent.getElementById("item-table-grid").append(ItemPrintout.createNewTable(elementId))
             htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
         }
             //Add total pricing to table
@@ -390,7 +390,7 @@ class OfferToPDFConverter implements OfferExporter {
                     ++tableCount
                     htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
                     elementId = "product-items" + "-" + tableCount
-                    htmlContent.getElementById("item-table-grid").append(ItemPrintout.seedNewTable(elementId))
+                    htmlContent.getElementById("item-table-grid").append(ItemPrintout.createNewTable(elementId))
                     tableItemsCount = 1
                 }
                 //Append Table Title and Header
@@ -403,7 +403,7 @@ class OfferToPDFConverter implements OfferExporter {
                         ++tableCount
                         htmlContent.getElementById(elementId).append(ItemPrintout.pageBreak())
                         elementId = "product-items" + "-" + tableCount
-                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.seedNewTable(elementId))
+                        htmlContent.getElementById("item-table-grid").append(ItemPrintout.createNewTable(elementId))
                         htmlContent.getElementById(elementId).append(ItemPrintout.tableHeader())
                         tableItemsCount = 1
                     }
@@ -500,7 +500,7 @@ class OfferToPDFConverter implements OfferExporter {
                                     """
         }
 
-        static String seedNewTable(String elementId) {
+        static String createNewTable(String elementId) {
             """<div class="product-items" id="${elementId}"></div>
             """
         }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -232,7 +232,7 @@ class OfferToPDFConverter implements OfferExporter {
         tableCount = 1
 
 
-        tableItemsCount = 1
+        pageItemsCount = 1
         //The maximum number of items per page
         int maxTableItems = 13
 

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -515,7 +515,7 @@
                     </div>
                 </div>
                 <div id="grid-table-footer">
-                    <div class="col-10 cost-summary-field">Overheads (20%)</div>
+                    <div class="col-10 cost-summary-field" id="overhead-percentage-value">Overheads (20%)</div>
                     <div class="row sub-total-costs" id="DATA_GENERATION-sub-overhead">
                         <div class="col-10 cost-summary-field">
                             Data Generation:
@@ -551,7 +551,7 @@
                         </div>
                     </div>
                     <div class="row total-costs" id="offer-vat">
-                        <div class="col-10 cost-summary-field">
+                        <div class="col-10 cost-summary-field" id="vat-percentage-value">
                             VAT (19%):
                         </div>
                         <div class="col-2 price-value" id="vat-cost-value">

--- a/offer-manager-app/src/main/resources/offer-template/offer.html
+++ b/offer-manager-app/src/main/resources/offer-template/offer.html
@@ -424,7 +424,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="pagebreak"></div>
+                <div id="template-page-break" class="pagebreak"></div>
                 <div class="product-items" id="product-items-2">
                     <div class="small-spacer"></div>
                     <h4>Project Management & Data Storage (PM & DS)</h4>

--- a/offer-manager-app/src/main/resources/offer-template/stylesheet.css
+++ b/offer-manager-app/src/main/resources/offer-template/stylesheet.css
@@ -209,12 +209,6 @@ h2 {
     font-size: 10pt;
 }
 
-#grid-table-header{
-    padding-left: 20px;
-    padding-right: 20px;
-    font-weight: bold;
-}
-
 .product-items{
     padding-left: 20px;
     padding-right: 20px;
@@ -338,7 +332,6 @@ footer {
   flex-wrap: wrap;
   /*margin-right: -15px;
   margin-left: -15px;*/
-
   padding-top: 5px;
   padding-bottom: 5px;
 }

--- a/offer-manager-app/src/main/resources/offer-template/stylesheet.css
+++ b/offer-manager-app/src/main/resources/offer-template/stylesheet.css
@@ -127,11 +127,11 @@ h2 {
 .table-row {
   padding-top: 2px;
   padding-bottom: 2px;
+  white-space:nowrap;
 }
 
 .total-costs-sum-row {
   font-weight: bold;
-  white-space:nowrap;
 }
 
 .signature {


### PR DESCRIPTION
**Description of changes**
Addresses #613 by adapting the dynamically changed layout to the html template. 

1. Introduce acronyms for the individual productCategories.
2. Add the acronyms to the table title and the net price listing in the subtotal footer of each productCategory table.  
3. Removes the overhead and total cost in the subtotal footer of each productCategory table. 
4. Rewrite final total pricing footer to match html template. 
5. Adapt the spacing calculation for each page hosting a productCategory table to avoid overflow into the fixed page footer.
6. Introduce `ItemPrintOut.pageBreak` method which is used to dynamically set pagebreaks when a page has no spacing left. 
7. Introduce `ItemPrintout.createNewTable` method which is used to create the scaffolding to which new productitems can be added.
8. Adapt `ItemPrintout.tableHeader `method to match html template. 

**Technical details**
The most critical change in this PR addresses the calculated spacing for the individual productCategory tables to avoid an overflow of the productitem table into the fixed footer. 
Currently this is done by incrementing the counter `productItemsCounter` for each element added to a page. 
This includes productItems, TableTitle and SubtableFooter since they all take up space on the page.   
The main problem is that this solution doesn't account for variations in the productItem descriptions length, which could lead to possible overflows into the fixed footer if the `maxTableItems` is set to high.

**How to test**
Compare the HTML Template in the `src/main/resources/offer-template/offer.html` with the dynamically created PDF of an offer. 
It's of critical importance that the tables don't overflow into the footer.
Therefore It would make sense to check if the spacing works for offers with a varied amount of productitems. 
Here is an example list of OfferIds of such offers.
`O_greiner_wydi_1`
`O_greiner_fudv_3`
`O_greiner_fudv_1`
`O_doctor_tdli_1`

