### PR TITLE
Fix #568 disable button copy product

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Disable 'Archive Product' button after deselection (`#547 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/547>`_)
 
+* Fix `Copy Product` button bein enabled even though the information was not changed (`#568 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/568>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Disable 'Archive Product' button after deselection (`#547 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/547>`_)
 
-* Fix `Copy Product` button bein enabled even though the information was not changed (`#568 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/568>`_)
+* Fix `Copy Product` button being enabled even though the information was not changed (`#568 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/568>`_)
 
 **Dependencies**
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductView.groovy
@@ -1,9 +1,6 @@
 package life.qbic.portal.offermanager.components.product.copy
 
-import com.vaadin.event.MouseEvents
-import com.vaadin.ui.Button
-import life.qbic.datamodel.dtos.business.ProductId
-import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.business.products.Converter
 import life.qbic.portal.offermanager.components.product.MaintainProductsController
 import life.qbic.portal.offermanager.components.product.create.CreateProductView
 
@@ -13,8 +10,7 @@ import life.qbic.portal.offermanager.components.product.create.CreateProductView
  *
  * The view is similar to the {@link CreateProductView} and updates the view to fit the copy product use case
  *
- * @since: 1.0.0
- *
+ * @since 1.0.0
  */
 
 class CopyProductView extends CreateProductView {
@@ -41,6 +37,27 @@ class CopyProductView extends CreateProductView {
             controller.copyProduct(viewModel.productCategory, viewModel.productDescription, viewModel.productName, Double.parseDouble(viewModel.productUnitPrice), viewModel.productUnit, copyProductViewModel.productId)
             clearAllFields()
         })
+    }
+
+    @Override
+    protected boolean allValuesValid() {
+        boolean wasModified = false
+        if (super.allValuesValid()) {
+            if (copyProductViewModel.productName != copyProductViewModel.originalProduct.productName) {
+                wasModified = true
+            } else if (copyProductViewModel.productDescription != copyProductViewModel.originalProduct.description) {
+                wasModified = true
+            } else if (copyProductViewModel.productUnitPrice != copyProductViewModel.originalProduct.unitPrice.toString()) {
+                wasModified = true
+            } else if (copyProductViewModel.productUnit != copyProductViewModel.originalProduct.unit) {
+                wasModified = true
+            } else if (copyProductViewModel.productCategory != Converter.getCategory(copyProductViewModel.originalProduct)) {
+                wasModified = true
+            } else {
+                wasModified = false
+            }
+        }
+        return super.allValuesValid() && wasModified
     }
 
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/copy/CopyProductViewModel.groovy
@@ -1,37 +1,24 @@
 package life.qbic.portal.offermanager.components.product.copy
 
-import life.qbic.business.products.Converter
-import life.qbic.datamodel.dtos.business.Offer
-import life.qbic.datamodel.dtos.business.ProductCategory
-import life.qbic.datamodel.dtos.business.ProductId
-import life.qbic.datamodel.dtos.business.services.DataStorage
-import life.qbic.datamodel.dtos.business.services.MetabolomicAnalysis
-import life.qbic.datamodel.dtos.business.services.PrimaryAnalysis
-import life.qbic.datamodel.dtos.business.services.Product
-import life.qbic.datamodel.dtos.business.services.ProjectManagement
-import life.qbic.datamodel.dtos.business.services.ProteomicAnalysis
-import life.qbic.datamodel.dtos.business.services.SecondaryAnalysis
-import life.qbic.datamodel.dtos.business.services.Sequencing
-import life.qbic.datamodel.dtos.general.Person
-import life.qbic.portal.offermanager.communication.EventEmitter
-import life.qbic.portal.offermanager.components.offer.create.ProductItemViewModel
-import life.qbic.portal.offermanager.components.product.MaintainProductsViewModel
-import life.qbic.portal.offermanager.components.product.create.CreateProductViewModel
-import life.qbic.portal.offermanager.dataresources.persons.CustomerResourceService
-import life.qbic.portal.offermanager.dataresources.persons.ProjectManagerResourceService
-import life.qbic.portal.offermanager.dataresources.products.ProductsResourcesService
 
+import life.qbic.business.products.Converter
+import life.qbic.datamodel.dtos.business.ProductId
+import life.qbic.datamodel.dtos.business.services.Product
+import life.qbic.portal.offermanager.communication.EventEmitter
+import life.qbic.portal.offermanager.components.product.create.CreateProductViewModel
 
 /**
  * <h1>Holds all values that the user specifies in the CreateProductView</h1>
  *
  * @since 1.0.0
- *
-*/
-class CopyProductViewModel extends CreateProductViewModel{
+ */
+class CopyProductViewModel extends CreateProductViewModel {
 
     EventEmitter<Product> productUpdate
     ProductId productId
+
+    Product originalProduct
+
     CopyProductViewModel(EventEmitter<Product> productUpdate) {
         super()
         this.productUpdate = productUpdate
@@ -41,6 +28,7 @@ class CopyProductViewModel extends CreateProductViewModel{
     }
 
     private void loadData(Product product) {
+        setOriginalProduct(product)
         productName = product.productName
         productDescription = product.description
         productUnit = product.unit


### PR DESCRIPTION
Addresses #568 
**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
The copy product button is no longer clickable when the entered information is exactly the same as the original information.

**Technical details**
The `allValuesValid`  method was overridden to also take into consideration the original values.
