### PR TITLE
Fix layout for CreatePerson and OfferOverview

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -29,7 +29,7 @@ import life.qbic.portal.offermanager.dataresources.offers.OfferOverview
  * @since 1.0.0
  */
 @Log4j2
-class OfferOverviewView extends FormLayout {
+class OfferOverviewView extends VerticalLayout {
 
     final private OfferOverviewModel model
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -30,7 +30,7 @@ import life.qbic.portal.offermanager.components.affiliation.create.CreateAffilia
  */
 
 @Log4j2
-class CreatePersonView extends FormLayout implements Resettable{
+class CreatePersonView extends VerticalLayout implements Resettable{
     protected final AppViewModel sharedViewModel
     protected final CreatePersonViewModel createPersonViewModel
     final CreatePersonController controller


### PR DESCRIPTION
Replace FormLayout with VerticalLayout for layouts that do only have layouts as children.

![image](https://user-images.githubusercontent.com/11536497/120322742-090bce00-c2e5-11eb-9c9c-08768a7bab7a.png)
