### PR TITLE
Check and validate changes in academicTitle during person creation and update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* A person can now be updated if only the associated academic title is changed (`#567 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/567>`_)
+
 * Small modifications for the offer layout  (`#620 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/620>`_)
 
 * Filter for product id in `life.qbic.portal.offermanager.components.offer.create.SelectItemsView` (`#599 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/599>`_)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -27,11 +27,11 @@ import life.qbic.portal.offermanager.components.affiliation.create.CreateAffilia
  * CreatePersonViewModel will be integrated into the qOffer 2.0 Portlet and provides an User Interface
  * with the intention of enabling a user the creation of a new person in the QBiC Database
  *
- * @since: 1.0.0
+ * @since 1.0.0
  */
 
 @Log4j2
-class CreatePersonView extends VerticalLayout implements Resettable{
+class CreatePersonView extends VerticalLayout implements Resettable {
     protected final AppViewModel sharedViewModel
     protected final CreatePersonViewModel createPersonViewModel
     final CreatePersonController controller
@@ -77,6 +77,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
 
         this.titleField = generateTitleSelector(createPersonViewModel.academicTitles)
         titleField.setRequiredIndicatorVisible(true)
+        titleField.setEmptySelectionAllowed(false)
 
         this.firstNameField = new TextField("First Name")
         firstNameField.setPlaceholder("First name")
@@ -107,7 +108,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
 
         this.addressAdditionComboBox = new ComboBox<>("Address Addition")
         addressAdditionComboBox.setRequiredIndicatorVisible(false)
-        addressAdditionComboBox.setItemCaptionGenerator({(it.addressAddition == ""|| it.addressAddition == " ")? "no address addition" : it.addressAddition})
+        addressAdditionComboBox.setItemCaptionGenerator({ (it.addressAddition == "" || it.addressAddition == " ") ? "no address addition" : it.addressAddition })
         addressAdditionComboBox.setEnabled(false)
         addressAdditionComboBox.setEmptySelectionAllowed(false)
 
@@ -186,25 +187,25 @@ class CreatePersonView extends VerticalLayout implements Resettable{
      */
     private void bindViewModel() {
 
-        this.titleField.addValueChangeListener({this.createPersonViewModel.academicTitle = it.value })
+        this.titleField.addValueChangeListener({ this.createPersonViewModel.academicTitle = it.value })
         createPersonViewModel.addPropertyChangeListener("academicTitle", {
             String newValue = it.newValue as String
             titleField.value = newValue ?: titleField.emptyValue
         })
 
-        this.firstNameField.addValueChangeListener({this.createPersonViewModel.firstName = it.value })
+        this.firstNameField.addValueChangeListener({ this.createPersonViewModel.firstName = it.value })
         createPersonViewModel.addPropertyChangeListener("firstName", {
             String newValue = it.newValue as String
             firstNameField.value = newValue ?: firstNameField.emptyValue
         })
 
-        this.lastNameField.addValueChangeListener({this.createPersonViewModel.lastName = it.value })
+        this.lastNameField.addValueChangeListener({ this.createPersonViewModel.lastName = it.value })
         createPersonViewModel.addPropertyChangeListener("lastName", {
             String newValue = it.newValue as String
             lastNameField.value = newValue ?: lastNameField.emptyValue
         })
 
-        this.emailField.addValueChangeListener({this.createPersonViewModel.email = it.value })
+        this.emailField.addValueChangeListener({ this.createPersonViewModel.email = it.value })
         createPersonViewModel.addPropertyChangeListener("email", {
             String newValue = it.newValue as String
             emailField.value = newValue ?: emailField.emptyValue
@@ -221,7 +222,8 @@ class CreatePersonView extends VerticalLayout implements Resettable{
                 addressAdditionComboBox.value = newValue
             } else {
                 addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
-                organisationComboBox.value = organisationComboBox.emptyValue            }
+                organisationComboBox.value = organisationComboBox.emptyValue
+            }
         })
 
         createPersonViewModel.addPropertyChangeListener("affiliationViewVisible", {
@@ -232,7 +234,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
         we listen to the valid properties. whenever the presenter resets values in the viewmodel
         and resets the valid properties the component error on the respective component is removed
         */
-        createPersonViewModel.addPropertyChangeListener({it ->
+        createPersonViewModel.addPropertyChangeListener({ it ->
             switch (it.propertyName) {
                 case "academicTitleValid":
                     if (it.newValue || it.newValue == null) {
@@ -278,7 +280,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
 
         ListDataProvider<Affiliation> dataProvider = organisation.affiliations
         this.addressAdditionComboBox.setDataProvider(dataProvider)
-        dataProvider.setSortOrder({it.addressAddition}, SortDirection.ASCENDING)
+        dataProvider.setSortOrder({ it.addressAddition }, SortDirection.ASCENDING)
 
         this.addressAdditionComboBox.setSelectedItem(dataProvider.getItems().getAt(0))
     }
@@ -288,9 +290,9 @@ class CreatePersonView extends VerticalLayout implements Resettable{
      */
     private void setupFieldValidators() {
 
-        Validator<String> nameValidator =  Validator.from({String value -> (value && !value.trim().empty)}, "Please provide a valid name.")
+        Validator<String> nameValidator = Validator.from({ String value -> (value && !value.trim().empty) }, "Please provide a valid name.")
         Validator<String> emailValidator = new EmailValidator("Please provide a valid email address.")
-        Validator<? extends Object> selectionValidator = Validator.from({o -> o != null}, "Please make a selection.")
+        Validator<? extends Object> selectionValidator = Validator.from({ o -> o != null }, "Please make a selection.")
 
         //Add Listeners to all Fields in the Form layout
         this.titleField.addSelectionListener({ selection ->
@@ -354,7 +356,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
         ComboBox<Organisation> organisationComboBox =
                 new ComboBox<>("Organisation")
         organisationComboBox.setPlaceholder("Select person affiliation organisation")
-        organisationComboBox.setItemCaptionGenerator({it.name})
+        organisationComboBox.setItemCaptionGenerator({ it.name })
         ListDataProvider<Organisation> dataProvider = new ListDataProvider<>(organisations)
         organisationComboBox.setDataProvider(dataProvider)
         organisationComboBox.setEmptySelectionAllowed(false)
@@ -389,10 +391,10 @@ class CreatePersonView extends VerticalLayout implements Resettable{
      */
     protected boolean allValuesValid() {
         return createPersonViewModel.academicTitleValid \
-            && createPersonViewModel.firstNameValid \
-            && createPersonViewModel.lastNameValid \
-            && createPersonViewModel.emailValid \
-            && createPersonViewModel.affiliationValid
+             && createPersonViewModel.firstNameValid \
+             && createPersonViewModel.lastNameValid \
+             && createPersonViewModel.emailValid \
+             && createPersonViewModel.affiliationValid
     }
 
     private void registerListeners() {
@@ -406,7 +408,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
                 List<Affiliation> affiliations = new ArrayList()
                 affiliations.add(createPersonViewModel.affiliation)
 
-                if(!createPersonViewModel.outdatedPerson){
+                if (!createPersonViewModel.outdatedPerson) {
                     controller.createNewPerson(firstName, lastName, title, email, affiliations)
                 }
 
@@ -421,7 +423,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
         })
 
         this.organisationComboBox.addSelectionListener({
-            if(it.selectedItem.isPresent()){
+            if (it.selectedItem.isPresent()) {
                 refreshAddressAdditions(it.selectedItem.get())
             }
         })
@@ -497,7 +499,7 @@ class CreatePersonView extends VerticalLayout implements Resettable{
     protected Optional<Organisation> findOrganisation(Affiliation affiliation) {
         Optional<Organisation> foundOrganisation = Optional.empty()
         createPersonViewModel.availableOrganisations.each {
-            if(affiliation in (it as Organisation).affiliations) foundOrganisation = Optional.of((it as Organisation))
+            if (affiliation in (it as Organisation).affiliations) foundOrganisation = Optional.of((it as Organisation))
         }
 
         return foundOrganisation

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -14,6 +14,7 @@ import com.vaadin.shared.ui.ContentMode
 import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
 import groovy.util.logging.Log4j2
+import life.qbic.datamodel.dtos.business.AcademicTitle
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.portal.offermanager.components.AppViewModel
 import life.qbic.portal.offermanager.components.Resettable
@@ -64,6 +65,7 @@ class CreatePersonView extends FormLayout implements Resettable{
         bindViewModel()
         setupFieldValidators()
         registerListeners()
+        initDefaultValues()
     }
 
     private AbstractOrderedLayout generateViewContent() {
@@ -74,6 +76,7 @@ class CreatePersonView extends FormLayout implements Resettable{
         defaultContent.addComponent(viewCaption)
 
         this.titleField = generateTitleSelector(createPersonViewModel.academicTitles)
+        titleField.setRequiredIndicatorVisible(true)
 
         this.firstNameField = new TextField("First Name")
         firstNameField.setPlaceholder("First name")
@@ -372,13 +375,22 @@ class CreatePersonView extends FormLayout implements Resettable{
     }
 
     /**
+     * Initializes the default values to be set in the components of the CreatePersonVieW
+     * @return
+     */
+    private void initDefaultValues() {
+        titleField.setSelectedItem(AcademicTitle.NONE.toString())
+        createPersonViewModel.academicTitle = AcademicTitle.NONE
+    }
+
+    /**
      * This is used to indicate whether all fields of this view are filled correctly.
      * It relies on the separate fields for validation.
      * @return
      */
     protected boolean allValuesValid() {
         return createPersonViewModel.academicTitleValid \
-            && createPersonViewModel.firstNameValid  \
+            && createPersonViewModel.firstNameValid \
             && createPersonViewModel.lastNameValid \
             && createPersonViewModel.emailValid \
             && createPersonViewModel.affiliationValid
@@ -509,5 +521,6 @@ class CreatePersonView extends FormLayout implements Resettable{
     void reset() {
         createPersonViewModel.reset()
         clearAllFields()
+        initDefaultValues()
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -379,8 +379,7 @@ class CreatePersonView extends FormLayout implements Resettable{
      * @return
      */
     private void initDefaultValues() {
-        titleField.setSelectedItem(AcademicTitle.NONE.toString())
-        createPersonViewModel.academicTitle = AcademicTitle.NONE
+        createPersonViewModel.academicTitle = AcademicTitle.NONE.toString()
     }
 
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -290,6 +290,16 @@ class CreatePersonView extends FormLayout implements Resettable{
         Validator<? extends Object> selectionValidator = Validator.from({o -> o != null}, "Please make a selection.")
 
         //Add Listeners to all Fields in the Form layout
+        this.titleField.addSelectionListener({ selection ->
+            ValidationResult result = selectionValidator.apply(selection.getValue(), new ValueContext(this.titleField))
+            if (result.isError()) {
+                createPersonViewModel.academicTitleValid = false
+                UserError error = new UserError(result.getErrorMessage())
+                titleField.setComponentError(error)
+            } else {
+                createPersonViewModel.academicTitleValid = true
+            }
+        })
         this.firstNameField.addValueChangeListener({ event ->
             ValidationResult result = nameValidator.apply(event.getValue(), new ValueContext(this.firstNameField))
             if (result.isError()) {
@@ -357,7 +367,7 @@ class CreatePersonView extends FormLayout implements Resettable{
                 new ComboBox<>("Academic Title")
         titleCombobox.setPlaceholder("Select academic title")
         titleCombobox.setItems(academicTitles)
-        titleCombobox.setEmptySelectionAllowed(true)
+        titleCombobox.setEmptySelectionAllowed(false)
         return titleCombobox
     }
 
@@ -367,7 +377,8 @@ class CreatePersonView extends FormLayout implements Resettable{
      * @return
      */
     protected boolean allValuesValid() {
-        return createPersonViewModel.firstNameValid \
+        return createPersonViewModel.academicTitleValid \
+            && createPersonViewModel.firstNameValid  \
             && createPersonViewModel.lastNameValid \
             && createPersonViewModel.emailValid \
             && createPersonViewModel.affiliationValid

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonViewModel.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager.components.person.create
 
 import groovy.beans.Bindable
+import life.qbic.datamodel.dtos.business.AcademicTitle
 import life.qbic.datamodel.dtos.business.Affiliation
 import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.ProjectManager
@@ -97,7 +98,7 @@ class CreatePersonViewModel implements Resettable{
 
     @Override
     void reset() {
-        setAcademicTitle(null)
+        setAcademicTitle(AcademicTitle.NONE.toString())
         setFirstName(null)
         setLastName(null)
         setEmail(null)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -223,10 +223,7 @@ class UpdatePersonView extends CreatePersonView{
      */
     @Override
     protected boolean allValuesValid() {
-        return createPersonViewModel.academicTitleValid \
-            && createPersonViewModel.firstNameValid \
-            && createPersonViewModel.lastNameValid \
-            && createPersonViewModel.emailValid \
-            && updatePersonViewModel.personUpdated
+        return super.allValuesValid()
+                && updatePersonViewModel.personUpdated
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -221,7 +221,8 @@ class UpdatePersonView extends CreatePersonView{
      * @return boolean which indicates if a person update can be triggered
      */
     protected boolean allValuesValid() {
-        return createPersonViewModel.firstNameValid \
+        return createPersonViewModel.academicTitleValid \
+            && createPersonViewModel.firstNameValid
             && createPersonViewModel.lastNameValid \
             && createPersonViewModel.emailValid
             && updatePersonViewModel.personUpdated

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -21,10 +21,9 @@ import life.qbic.portal.offermanager.components.person.create.CreatePersonView
  * <p>Since both views should look the same changes of the {@link CreatePersonView} should also be reflected in the {@link UpdatePersonView}</p>
  *
  * @since 1.0.0
- *
-*/
+ */
 @Log4j2
-class UpdatePersonView extends CreatePersonView{
+class UpdatePersonView extends CreatePersonView {
     private final UpdatePersonViewModel updatePersonViewModel
     private final AppViewModel sharedViewModel
 
@@ -54,18 +53,16 @@ class UpdatePersonView extends CreatePersonView{
         Label currentAffiliationLabel = new Label("Current Affiliations")
         affiliations.setSelectionMode(Grid.SelectionMode.NONE)
         defaultContent.addComponent(currentAffiliationLabel, 3)
-        defaultContent.addComponent(affiliations,4)
+        defaultContent.addComponent(affiliations, 4)
         //add a heading for adding a new affiliation
         Label newAffiliation = new Label("Add a new affiliation")
-        defaultContent.addComponent(newAffiliation,5)
+        defaultContent.addComponent(newAffiliation, 5)
 
         //add the add button
         addAffiliationButton = new Button("Add Affiliation")
         addAffiliationButton.setIcon(VaadinIcons.PLUS)
         addAffiliationButton.setEnabled(false)
-        titleField.setRequiredIndicatorVisible(true)
-        titleField.setEmptySelectionAllowed(false)
-        buttonLayout.addComponent(addAffiliationButton,0)
+        buttonLayout.addComponent(addAffiliationButton, 0)
     }
 
     private void generateAffiliationGrid() {
@@ -133,7 +130,7 @@ class UpdatePersonView extends CreatePersonView{
                 personFilterRow)
     }
 
-    private void registerListener(){
+    private void registerListener() {
         submitButtonClickListenerRegistration.remove()
         submitButton.addClickListener({
             try {
@@ -144,7 +141,7 @@ class UpdatePersonView extends CreatePersonView{
                 String email = updatePersonViewModel.email
                 List<Affiliation> affiliations = updatePersonViewModel.affiliationList
 
-                if(updatePersonViewModel.outdatedPerson){
+                if (updatePersonViewModel.outdatedPerson) {
                     controller.updatePerson(updatePersonViewModel.outdatedPerson, firstName, lastName, title, email, affiliations)
                 }
 
@@ -158,30 +155,30 @@ class UpdatePersonView extends CreatePersonView{
             }
         })
 
-        updatePersonViewModel.addPropertyChangeListener("affiliationValid",{
-            if(updatePersonViewModel.affiliationValid ||updatePersonViewModel.affiliationValid == null){
+        updatePersonViewModel.addPropertyChangeListener("affiliationValid", {
+            if (updatePersonViewModel.affiliationValid || updatePersonViewModel.affiliationValid == null) {
                 organisationComboBox.componentError = null
                 addressAdditionComboBox.componentError = null
                 addAffiliationButton.setEnabled(true)
-            }else{
+            } else {
                 addAffiliationButton.setEnabled(false)
             }
         })
 
         addAffiliationButton.addClickListener({
-            if(!updatePersonViewModel.affiliationList.contains(updatePersonViewModel.affiliation)){
+            if (!updatePersonViewModel.affiliationList.contains(updatePersonViewModel.affiliation)) {
                 updatePersonViewModel.affiliationList << updatePersonViewModel.affiliation
                 affiliations.dataProvider.refreshAll()
                 updatePersonViewModel.personUpdated = true
-            }else{
+            } else {
                 sharedViewModel.failureNotifications.add("Cannot add the selected affiliation. It was already associated with the person.")
                 addAffiliationButton.setEnabled(false)
             }
             resetAffiliation()
         })
 
-        updatePersonViewModel.addPropertyChangeListener({it ->
-            if(updatePersonViewModel.outdatedPerson){
+        updatePersonViewModel.addPropertyChangeListener({ it ->
+            if (updatePersonViewModel.outdatedPerson) {
                 switch (it.propertyName) {
                     case "academicTitle":
                         boolean titleChanged = updatePersonViewModel.academicTitle != updatePersonViewModel.outdatedPerson.title.toString()
@@ -207,7 +204,7 @@ class UpdatePersonView extends CreatePersonView{
         })
     }
 
-    private void resetAffiliation(){
+    private void resetAffiliation() {
         organisationComboBox.clear()
         addressAdditionComboBox.clear()
         createPersonViewModel.affiliationValid = null

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -63,7 +63,8 @@ class UpdatePersonView extends CreatePersonView{
         addAffiliationButton = new Button("Add Affiliation")
         addAffiliationButton.setIcon(VaadinIcons.PLUS)
         addAffiliationButton.setEnabled(false)
-
+        titleField.setRequiredIndicatorVisible(true)
+        titleField.setEmptySelectionAllowed(false)
         buttonLayout.addComponent(addAffiliationButton,0)
     }
 
@@ -220,11 +221,12 @@ class UpdatePersonView extends CreatePersonView{
      *
      * @return boolean which indicates if a person update can be triggered
      */
+    @Override
     protected boolean allValuesValid() {
         return createPersonViewModel.academicTitleValid \
-            && createPersonViewModel.firstNameValid
+            && createPersonViewModel.firstNameValid \
             && createPersonViewModel.lastNameValid \
-            && createPersonViewModel.emailValid
+            && createPersonViewModel.emailValid \
             && updatePersonViewModel.personUpdated
     }
 }


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked
- [X] `CHANGELOG.rst` is updated

**Description of changes**
Addresses #567 by adding a `selectionlistener` to the academic `titleField` component in the `updateView` and `createpersonView`. The selected value is then included in the validation method which determines if the submit button should be enabled. This enables the following: 

1. Updating a person when solely the associated academic title is changed 
2. Forces the user to explicitly select an academic title during person creation 

**Technical details**
Since the `updatePersonView` extends the `createPersonView ` this change will also force the user to select an academic title during new person creation. 
For this reason selecting an empty selection in the title combobox is also disabled in this PR.  
I'm unsure why the `setEmptySelectionAllowed` property was set possible in the first place for the `titleField`since a PM can select the title "NONE" explicitly from the selectable titles, if the created person has no academic title.
Let me know if this has to be changed back 👍 

**Additional Info** 
Another improvement could also be to set the default value of the titlefield to "NONE" in the `createPersonView` for easier person creation? 


