### PR TITLE
Wrong product description display

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Fix `Copy Product` button being enabled even though the information was not changed (`#568 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/568>`_)
 
+* Fix the misplaced product description panel (`#640 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/640>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -46,6 +46,7 @@ class MaintainProductsView extends FormLayout {
     private Button archiveProduct
     private Panel productDescription
     private VerticalLayout maintenanceLayout
+    private HorizontalLayout descriptionLayout
 
     CreateProductView createProductView
     CopyProductView copyProductView
@@ -60,8 +61,8 @@ class MaintainProductsView extends FormLayout {
         setupTitle()
         createButtons()
         setupGrid()
-        setupOverviewLayout()
         setupPanel()
+        setupOverviewLayout()
         addSubViews()
         setupListeners()
     }
@@ -128,16 +129,15 @@ class MaintainProductsView extends FormLayout {
     }
 
     private void setupPanel(){
-        HorizontalLayout descriptionLayout = new HorizontalLayout()
+        descriptionLayout = new HorizontalLayout()
         descriptionLayout.setSizeFull()
-        this.addComponent(descriptionLayout)
 
         productDescription = new Panel("Product Description")
         descriptionLayout.addComponents(productDescription)
     }
 
     private void setupOverviewLayout(){
-        maintenanceLayout = new VerticalLayout(buttonLayout, productGrid)
+        maintenanceLayout = new VerticalLayout(buttonLayout, productGrid, descriptionLayout)
         maintenanceLayout.setSizeFull()
         maintenanceLayout.setMargin(false)
         maintenanceLayout.addComponents()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -106,6 +106,7 @@ class MaintainProductsView extends FormLayout {
 
         productGrid.setWidthFull()
         productGrid.sort("ProductId", SortDirection.ASCENDING)
+        productGrid.setHeightByRows(6)
 
         ListDataProvider<Product> productsDataProvider = setupDataProvider()
         setupFilters(productsDataProvider)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsView.groovy
@@ -134,6 +134,11 @@ class MaintainProductsView extends FormLayout {
         descriptionLayout.setSizeFull()
 
         productDescription = new Panel("Product Description")
+        VerticalLayout content = new VerticalLayout()
+        content.setMargin(true)
+        content.setSpacing(false)
+        content.addComponent(new Label("Select a product to see its detailed description."))
+        productDescription.setContent(content)
         descriptionLayout.addComponents(productDescription)
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/create/CreateProductView.groovy
@@ -27,7 +27,7 @@ import life.qbic.portal.offermanager.components.product.MaintainProductsControll
  * @since 1.0.0
  *
 */
-class CreateProductView extends HorizontalLayout{
+class CreateProductView extends VerticalLayout{
 
     protected final CreateProductViewModel viewModel
     protected final MaintainProductsController controller
@@ -65,14 +65,15 @@ class CreateProductView extends HorizontalLayout{
         //add textfields and boxes
         HorizontalLayout sharedLayout = new HorizontalLayout(productUnitPriceField,productUnitComboBox)
         sharedLayout.setWidthFull()
+        sharedLayout.setMargin(false)
         HorizontalLayout buttons = new HorizontalLayout(abortButton,createProductButton)
 
         VerticalLayout sideLayout = new VerticalLayout(titleLabel,productNameField,productDescriptionField,sharedLayout,productCategoryComboBox,buttons)
         sideLayout.setSizeFull()
+        sideLayout.setMargin(false)
         sideLayout.setComponentAlignment(buttons, Alignment.BOTTOM_RIGHT)
 
         this.setMargin(false)
-        this.setSpacing(false)
         this.setSizeFull()
 
         this.addComponents(sideLayout)


### PR DESCRIPTION
fixes #640 

With this PR I placed the product panel into the views layout, to avoid the panel being part of the Create and CopyProductViews. 

Furthremore, I realised that the views are jumping if you switch between them and fixed it by using the right layout and setting margin to false