### PR TITLE
Generate overhead cost footer only when productgroups are present

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
+* Only list overhead costs of productGroup items present in offer in Offer PDF  (`#642 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/642>`_)
+
 * Small modifications for the offer layout  (`#620 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/620>`_)
 
 * Filter for product id in `life.qbic.portal.offermanager.components.offer.create.SelectItemsView` (`#599 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/599>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Added**
 
-* Only list overhead costs of productGroup items present in offer in Offer PDF  (`#642 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/642>`_)
+* Only list overhead costs of productGroup items present in offer in Offer PDF  (`#643 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/643>`_)
 
 * Small modifications for the offer layout  (`#620 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/620>`_)
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -439,14 +439,14 @@ class OfferToPDFConverter implements OfferExporter {
 
     void clearUnusedProductGroupInformation() {
 
-        boolean dataGenerationItemsExists
-        boolean dataAnalysisItemsExists
+        boolean dataGenerationItemsExists = true
+        boolean dataAnalysisItemsExists = true
         //Remove overhead cost listing of productGroup from grid-table-footer if an offer has no items associated with a productGroup
         productItemsMap.each { ProductGroups key, List<ProductItem> value ->
             if (value.empty) {
                 switch (key) {
                     case ProductGroups.DATA_GENERATION:
-                        dataGenerationItemsExists = false
+                        dataGenerationItemsExists= false
                         htmlContent.getElementById("${key.toString()}-sub-overhead").remove()
                         break
                     case ProductGroups.DATA_ANALYSIS:
@@ -463,6 +463,7 @@ class OfferToPDFConverter implements OfferExporter {
         //Remove overhead percentage title when no data generation and data analysis items are stored in the offer
         if (!dataGenerationItemsExists && !dataAnalysisItemsExists) {
             htmlContent.getElementById("overhead-percentage-value").remove()
+            htmlContent.getElementById("offer-overhead").remove()
         }
     }
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -463,7 +463,8 @@ class OfferToPDFConverter implements OfferExporter {
         //Remove overhead percentage title when no data generation and data analysis items are stored in the offer
         if (!dataGenerationItemsExists && !dataAnalysisItemsExists) {
             htmlContent.getElementById("overhead-percentage-value").remove()
-            htmlContent.getElementById("offer-overhead").remove()
+            //Remove the overscore, if no overhead cost listing is created
+            htmlContent.getElementById("offer-overhead").removeClass("single-overscore")
         }
     }
     /**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferToPDFConverter.groovy
@@ -175,6 +175,7 @@ class OfferToPDFConverter implements OfferExporter {
         setTaxationStatement()
         setTaxationRatioInSummary()
         setQuotationDetails()
+        clearUnusedProductGroupInformation()
     }
 
     private void generatePDF() {
@@ -433,6 +434,35 @@ class OfferToPDFConverter implements OfferExporter {
                 // Update footer Prices
                 setSubTotalPrices(productGroup, items)
             }
+        }
+    }
+
+    void clearUnusedProductGroupInformation() {
+
+        boolean dataGenerationItemsExists
+        boolean dataAnalysisItemsExists
+        //Remove overhead cost listing of productGroup from grid-table-footer if an offer has no items associated with a productGroup
+        productItemsMap.each { ProductGroups key, List<ProductItem> value ->
+            if (value.empty) {
+                switch (key) {
+                    case ProductGroups.DATA_GENERATION:
+                        dataGenerationItemsExists = false
+                        htmlContent.getElementById("${key.toString()}-sub-overhead").remove()
+                        break
+                    case ProductGroups.DATA_ANALYSIS:
+                        dataAnalysisItemsExists = false
+                        htmlContent.getElementById("${key.toString()}-sub-overhead").remove()
+                        break
+                    default:
+                        log.error("Unclassified ProductGroup found")
+                        break
+                }
+            }
+
+        }
+        //Remove overhead percentage title when no data generation and data analysis items are stored in the offer
+        if (!dataGenerationItemsExists && !dataAnalysisItemsExists) {
+            htmlContent.getElementById("overhead-percentage-value").remove()
         }
     }
     /**


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] `CHANGELOG.rst` is updated

**Description of changes**
This PR addresses #643 by adding a method which removes the overhead cost listing for productgroups which are not stored in the offer from the table footer. 
![Bildschirmfoto 2021-06-02 um 15 44 53](https://user-images.githubusercontent.com/29627977/120491453-8a349500-c3b9-11eb-8775-841be635f53f.png)
![Bildschirmfoto 2021-06-02 um 15 44 37](https://user-images.githubusercontent.com/29627977/120491457-8a349500-c3b9-11eb-97d6-2d8c2c23c001.png)
![Bildschirmfoto 2021-06-02 um 15 44 26](https://user-images.githubusercontent.com/29627977/120491458-8acd2b80-c3b9-11eb-8c23-58493917ca0e.png)

