### PR TITLE
Listen to affiliations of person instead of selected affiliation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Update of person entries is no longer blocked by ignored affiliation selection (`#654 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/654>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -44,6 +44,11 @@ class UpdatePersonView extends CreatePersonView {
         submitButton.caption = "Update Person"
         abortButton.caption = "Abort Person Update"
 
+        // remove required indicator since affiliationValid is no longer required to update
+        // it is replaced by affiliationsValid
+        organisationComboBox.setRequiredIndicatorVisible(false)
+        addressAdditionComboBox.setRequiredIndicatorVisible(false)
+
         //be careful when adding new components to the view
         //it is based on the CreatePersonView, you might disrupt the view when adding new components to the wrong position
 
@@ -201,6 +206,18 @@ class UpdatePersonView extends CreatePersonView {
                 }
                 submitButton.enabled = allValuesValid()
             }
+
+            updatePersonViewModel.affiliationList.addPropertyChangeListener({
+                //validation
+                updatePersonViewModel.affiliationsValid = ! updatePersonViewModel.affiliationList.isEmpty()
+                if(updatePersonViewModel.outdatedPerson) {
+                    List<Affiliation> originalList = updatePersonViewModel.outdatedPerson?.affiliations
+                    List<Affiliation> viewModelList = updatePersonViewModel.affiliationList
+                    boolean affiliationsChanged = ((originalList - viewModelList) + (viewModelList - originalList))
+                    // set the changed needs to be triggered after the validity update
+                    updatePersonViewModel.personUpdated = updatePersonViewModel.affiliationsValid && affiliationsChanged
+                }
+            })
         })
     }
 
@@ -220,7 +237,11 @@ class UpdatePersonView extends CreatePersonView {
      */
     @Override
     protected boolean allValuesValid() {
-        return super.allValuesValid()
-                && updatePersonViewModel.personUpdated
+        return createPersonViewModel.academicTitleValid \
+             && createPersonViewModel.firstNameValid \
+             && createPersonViewModel.lastNameValid \
+             && createPersonViewModel.emailValid \
+             && updatePersonViewModel.personUpdated \
+             && updatePersonViewModel.affiliationsValid
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -211,11 +211,13 @@ class UpdatePersonView extends CreatePersonView {
                 //validation
                 updatePersonViewModel.affiliationsValid = ! updatePersonViewModel.affiliationList.isEmpty()
                 if(updatePersonViewModel.outdatedPerson) {
-                    List<Affiliation> originalList = updatePersonViewModel.outdatedPerson?.affiliations
+                    List<Affiliation> originalList = updatePersonViewModel.outdatedPerson.affiliations
                     List<Affiliation> viewModelList = updatePersonViewModel.affiliationList
-                    boolean affiliationsChanged = ((originalList - viewModelList) + (viewModelList - originalList))
+                    boolean affiliationsChanged = ! (originalList == viewModelList)
                     // set the changed needs to be triggered after the validity update
                     updatePersonViewModel.personUpdated = updatePersonViewModel.affiliationsValid && affiliationsChanged
+                } else {
+                    log.warn("Tried to check for person affiliation changes. There is no person to update.")
                 }
             })
         })

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
@@ -6,7 +6,6 @@ import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.ProjectManager
 import life.qbic.datamodel.dtos.general.Person
 import life.qbic.portal.offermanager.components.Resettable
-import life.qbic.portal.offermanager.dataresources.persons.PersonResourceService
 import life.qbic.portal.offermanager.communication.EventEmitter
 import life.qbic.portal.offermanager.components.person.create.CreatePersonViewModel
 import life.qbic.portal.offermanager.dataresources.ResourcesService
@@ -32,6 +31,9 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
     @Bindable
     Boolean personUpdated
 
+    @Bindable
+    Boolean affiliationsValid
+
     UpdatePersonViewModel(ResourcesService<Customer> customerService,
                           ResourcesService<ProjectManager> managerResourceService,
                           ResourcesService<Affiliation> affiliationService,
@@ -39,7 +41,7 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
                           ResourcesService<Person> personResourceService) {
         super(customerService, managerResourceService, affiliationService, personResourceService)
         this.customerUpdate = customerUpdate
-        affiliationList = new ArrayList<Affiliation>()
+        affiliationList = new ObservableList(new ArrayList<Affiliation>())
         personUpdated = false
 
         this.customerUpdate.register((Person person) -> {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
@@ -66,8 +66,8 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
 
     @Override
     void reset() {
-        super.reset()
-        setOutdatedPerson(null)
         affiliationList.clear()
+        setOutdatedPerson(null)
+        super.reset()
     }
 }


### PR DESCRIPTION
Addresses #654 

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] `CHANGELOG.rst` is updated

**Description of changes**
The affiliations of the person that was updated were wrongly assigned. Now it checks the assigned affiliations that are also passed to the use case instead of an attachable organisation that is ignored by the use case.
