### PR TITLE
Disable add affilation button until a new affilation is selected

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Disable the affiliation attachment during person update if no affiliation is selected (`#656 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/656>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -280,10 +280,10 @@ class CreatePersonView extends VerticalLayout implements Resettable {
      * refreshes assuming no organisation is selected
      */
     protected void refreshAddressAdditions() {
-        addressAdditionComboBox.setEnabled(false)
-        ListDataProvider<Affiliation> dataProvider = []
+        ListDataProvider<Affiliation> dataProvider = new ListDataProvider<>(new ArrayList<Affiliation>())
         this.addressAdditionComboBox.setDataProvider(dataProvider)
         this.addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
+        addressAdditionComboBox.setEnabled(false)
     }
 
     protected void refreshAddressAdditions(Organisation organisation) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -221,6 +221,7 @@ class CreatePersonView extends VerticalLayout implements Resettable {
                 organisationComboBox.value = findOrganisation(newValue).get()
                 addressAdditionComboBox.value = newValue
             } else {
+                refreshAddressAdditions()
                 addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
                 organisationComboBox.value = organisationComboBox.emptyValue
             }
@@ -273,6 +274,16 @@ class CreatePersonView extends VerticalLayout implements Resettable {
         createPersonViewModel.availableOrganisations.addPropertyChangeListener({
             organisationComboBox.getDataProvider().refreshAll()
         })
+    }
+
+    /**
+     * refreshes assuming no organisation is selected
+     */
+    protected void refreshAddressAdditions() {
+        addressAdditionComboBox.setEnabled(false)
+        ListDataProvider<Affiliation> dataProvider = []
+        this.addressAdditionComboBox.setDataProvider(dataProvider)
+        this.addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
     }
 
     protected void refreshAddressAdditions(Organisation organisation) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -156,7 +156,7 @@ class UpdatePersonView extends CreatePersonView {
         })
 
         updatePersonViewModel.addPropertyChangeListener("affiliationValid", {
-            if (updatePersonViewModel.affiliationValid || updatePersonViewModel.affiliationValid == null) {
+            if (updatePersonViewModel.affiliationValid) {
                 organisationComboBox.componentError = null
                 addressAdditionComboBox.componentError = null
                 addAffiliationButton.setEnabled(true)

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -155,13 +155,10 @@ class UpdatePersonView extends CreatePersonView {
             }
         })
 
-        updatePersonViewModel.addPropertyChangeListener("affiliationValid", {
-            if (updatePersonViewModel.affiliationValid) {
-                organisationComboBox.componentError = null
-                addressAdditionComboBox.componentError = null
-                addAffiliationButton.setEnabled(true)
-            } else {
-                addAffiliationButton.setEnabled(false)
+        updatePersonViewModel.addPropertyChangeListener({
+            if (it.propertyName == "affiliation" || it.propertyName == "affiliationValid") {
+                boolean buttonEnabled = updatePersonViewModel.affiliation && updatePersonViewModel.affiliationValid
+                addAffiliationButton.setEnabled(buttonEnabled)
             }
         })
 


### PR DESCRIPTION
- [X] This comment contains a description of changes (with reason)
- [X] Referenced issue is linked

**Description of changes**
This PR closes #656 by disabling the "add affilation" button until a new affilation is selected. 
This also happens if customer was updated previously. 

**Miscellanous** 
Please note, that currently the update person button can only be clicked after a new organisation is selected, even if a new affilation was added to the customer. This is addressed in #655 

**Additional context**
https://user-images.githubusercontent.com/29627977/121347170-29f8a280-c927-11eb-9c3d-ad74d327f11d.mov


