### PR TITLE
Hotfix 1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,18 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-1.0.1 (2020-06-07)
+1.0.2 (2021-06-07)
+------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+**Deprecated**
+
+1.0.1 (2021-06-07)
 ------------------
 
 **Added**
@@ -19,7 +30,7 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Deprecated**
 
-1.0.0 (2020-06-04)
+1.0.0 (2021-06-04)
 ------------------
 
 **Added**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Disable the affiliation attachment during person update if no affiliation is selected (`#656 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/656>`_)
+
 **Dependencies**
 
 **Deprecated**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Update of person entries is no longer blocked by ignored affiliation selection (`#654 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/654>`_)
+
 * Disable the affiliation attachment during person update if no affiliation is selected (`#656 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/656>`_)
 
 **Dependencies**

--- a/offer-manager-app/pom.xml
+++ b/offer-manager-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>offer-manager</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>offer-manager-domain</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
+            <version>1.0.2-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/create/CreatePersonView.groovy
@@ -221,6 +221,7 @@ class CreatePersonView extends VerticalLayout implements Resettable {
                 organisationComboBox.value = findOrganisation(newValue).get()
                 addressAdditionComboBox.value = newValue
             } else {
+                refreshAddressAdditions()
                 addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
                 organisationComboBox.value = organisationComboBox.emptyValue
             }
@@ -273,6 +274,16 @@ class CreatePersonView extends VerticalLayout implements Resettable {
         createPersonViewModel.availableOrganisations.addPropertyChangeListener({
             organisationComboBox.getDataProvider().refreshAll()
         })
+    }
+
+    /**
+     * refreshes assuming no organisation is selected
+     */
+    protected void refreshAddressAdditions() {
+        ListDataProvider<Affiliation> dataProvider = new ListDataProvider<>(new ArrayList<Affiliation>())
+        this.addressAdditionComboBox.setDataProvider(dataProvider)
+        this.addressAdditionComboBox.value = addressAdditionComboBox.emptyValue
+        addressAdditionComboBox.setEnabled(false)
     }
 
     protected void refreshAddressAdditions(Organisation organisation) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -155,13 +155,10 @@ class UpdatePersonView extends CreatePersonView {
             }
         })
 
-        updatePersonViewModel.addPropertyChangeListener("affiliationValid", {
-            if (updatePersonViewModel.affiliationValid || updatePersonViewModel.affiliationValid == null) {
-                organisationComboBox.componentError = null
-                addressAdditionComboBox.componentError = null
-                addAffiliationButton.setEnabled(true)
-            } else {
-                addAffiliationButton.setEnabled(false)
+        updatePersonViewModel.addPropertyChangeListener({
+            if (it.propertyName == "affiliation" || it.propertyName == "affiliationValid") {
+                boolean buttonEnabled = updatePersonViewModel.affiliation && updatePersonViewModel.affiliationValid
+                addAffiliationButton.setEnabled(buttonEnabled)
             }
         })
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonView.groovy
@@ -44,6 +44,11 @@ class UpdatePersonView extends CreatePersonView {
         submitButton.caption = "Update Person"
         abortButton.caption = "Abort Person Update"
 
+        // remove required indicator since affiliationValid is no longer required to update
+        // it is replaced by affiliationsValid
+        organisationComboBox.setRequiredIndicatorVisible(false)
+        addressAdditionComboBox.setRequiredIndicatorVisible(false)
+
         //be careful when adding new components to the view
         //it is based on the CreatePersonView, you might disrupt the view when adding new components to the wrong position
 
@@ -198,6 +203,20 @@ class UpdatePersonView extends CreatePersonView {
                 }
                 submitButton.enabled = allValuesValid()
             }
+
+            updatePersonViewModel.affiliationList.addPropertyChangeListener({
+                //validation
+                updatePersonViewModel.affiliationsValid = ! updatePersonViewModel.affiliationList.isEmpty()
+                if(updatePersonViewModel.outdatedPerson) {
+                    List<Affiliation> originalList = updatePersonViewModel.outdatedPerson.affiliations
+                    List<Affiliation> viewModelList = updatePersonViewModel.affiliationList
+                    boolean affiliationsChanged = ! (originalList == viewModelList)
+                    // set the changed needs to be triggered after the validity update
+                    updatePersonViewModel.personUpdated = updatePersonViewModel.affiliationsValid && affiliationsChanged
+                } else {
+                    log.warn("Tried to check for person affiliation changes. There is no person to update.")
+                }
+            })
         })
     }
 
@@ -217,7 +236,11 @@ class UpdatePersonView extends CreatePersonView {
      */
     @Override
     protected boolean allValuesValid() {
-        return super.allValuesValid()
-                && updatePersonViewModel.personUpdated
+        return createPersonViewModel.academicTitleValid \
+             && createPersonViewModel.firstNameValid \
+             && createPersonViewModel.lastNameValid \
+             && createPersonViewModel.emailValid \
+             && updatePersonViewModel.personUpdated \
+             && updatePersonViewModel.affiliationsValid
     }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/person/update/UpdatePersonViewModel.groovy
@@ -6,7 +6,6 @@ import life.qbic.datamodel.dtos.business.Customer
 import life.qbic.datamodel.dtos.business.ProjectManager
 import life.qbic.datamodel.dtos.general.Person
 import life.qbic.portal.offermanager.components.Resettable
-import life.qbic.portal.offermanager.dataresources.persons.PersonResourceService
 import life.qbic.portal.offermanager.communication.EventEmitter
 import life.qbic.portal.offermanager.components.person.create.CreatePersonViewModel
 import life.qbic.portal.offermanager.dataresources.ResourcesService
@@ -32,6 +31,9 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
     @Bindable
     Boolean personUpdated
 
+    @Bindable
+    Boolean affiliationsValid
+
     UpdatePersonViewModel(ResourcesService<Customer> customerService,
                           ResourcesService<ProjectManager> managerResourceService,
                           ResourcesService<Affiliation> affiliationService,
@@ -39,7 +41,7 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
                           ResourcesService<Person> personResourceService) {
         super(customerService, managerResourceService, affiliationService, personResourceService)
         this.customerUpdate = customerUpdate
-        affiliationList = new ArrayList<Affiliation>()
+        affiliationList = new ObservableList(new ArrayList<Affiliation>())
         personUpdated = false
 
         this.customerUpdate.register((Person person) -> {
@@ -64,8 +66,8 @@ class UpdatePersonViewModel extends CreatePersonViewModel implements Resettable{
 
     @Override
     void reset() {
-        super.reset()
-        setOutdatedPerson(null)
         affiliationList.clear()
+        setOutdatedPerson(null)
+        super.reset()
     }
 }

--- a/offer-manager-domain/pom.xml
+++ b/offer-manager-domain/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>offer-manager</artifactId>
 		<groupId>life.qbic</groupId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.0.2-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<module>offer-manager-app</module>
 	</modules>
 	<artifactId>offer-manager</artifactId>
-	<version>1.0.1-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>1.0.2-SNAPSHOT</version> <!-- <<QUBE_FORCE_BUMP>> -->
 	<groupId>life.qbic</groupId>
 	<name>The new offer manager</name>
 	<url>http://github.com/qbicsoftware/qOffer_2.0</url>


### PR DESCRIPTION
1.0.2 (2021-06-07)
------------------

**Added**

**Fixed**

* Update of person entries is no longer blocked by ignored affiliation selection (#654)

* Disable the affiliation attachment during person update if no affiliation is selected (#656)

**Dependencies**

**Deprecated**