### PR TITLE
#685 Match Offer PDF filename to Offer ID Prefix 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 **Fixed**
 
+* Include Offer ID Prefix in Offer PDF filename (`#685 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/685>`_)
+
 **Dependencies**
 
 * ``mysql:mysql-connector-java:8.0.24`` -> ``8.0.25``

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
@@ -44,6 +44,8 @@ class OfferFileNameFormatter {
         /**
          * Answers a string containing a concise, human-readable
          * description of the receiver.
+         * The returned format is: 
+         *            <date>_O_<pi-name>_<offer-randid>_<offer-version>.pdf
          *
          * @return String a printable representation for the receiver.
          */

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
@@ -7,7 +7,7 @@ import java.time.LocalDate
 /**
  * <h1>Formats the filename for an offer</h1>
  *
- * <p>An offers file name should contain the date of the offer creation, the project conserved part and the offer version</p>
+ * <p>An offers file name should contain the date of the offer creation, a type prefix, the project conserved part, a randomly generated id and the offer version</p>
  *
  * @since 1.0.0
  *
@@ -17,16 +17,15 @@ class OfferFileNameFormatter {
     /**
      * Returns an offer file name in this schema:
      *
-     * Q_<year>_<month>_<day>_<project-conserved-part>_<random-id-part>_v<offer-version>.pdf
+     * <year>_<month>_<day>_O_<project-conserved-part>_<random-id-part>_<offer-version>.pdf
      * @param offer
      * @return
      */
     static String getFileNameForOffer(Offer offer) {
         LocalDate date = offer.modificationDate.toLocalDate()
         String dateString = createDateString(date)
-        return "Q_${dateString}_" +
-                "${offer.identifier.projectConservedPart}_${offer.identifier.randomPart}_" +
-                "v${offer.identifier.version}.pdf"
+        String typePrefix = "O"
+        return "${dateString}_${typePrefix}_${offer.identifier.projectConservedPart}_${offer.identifier.randomPart}_${offer.identifier.version}.pdf"
     }
 
     private static String createDateString(LocalDate date) {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferFileNameFormatter.groovy
@@ -1,6 +1,7 @@
 package life.qbic.portal.offermanager
 
 import life.qbic.datamodel.dtos.business.Offer
+import life.qbic.datamodel.dtos.business.OfferId
 
 import java.time.LocalDate
 
@@ -23,13 +24,35 @@ class OfferFileNameFormatter {
      */
     static String getFileNameForOffer(Offer offer) {
         LocalDate date = offer.modificationDate.toLocalDate()
-        String dateString = createDateString(date)
-        String typePrefix = "O"
-        return "${dateString}_${typePrefix}_${offer.identifier.projectConservedPart}_${offer.identifier.randomPart}_${offer.identifier.version}.pdf"
+        OfferFileName fileName = new OfferFileName(date, offer.getIdentifier())
+        return fileName.toString()
     }
 
-    private static String createDateString(LocalDate date) {
-        return String.format("%04d_%02d_%02d", date.getYear(), date.getMonthValue(), date.getDayOfMonth())
+    private static class OfferFileName {
+        LocalDate date
+        OfferId offerId
+
+        OfferFileName(LocalDate date, OfferId offerId) {
+            this.date = date
+            this.offerId = offerId
+        }
+
+        private static String createDateString(LocalDate date) {
+            return String.format("%04d_%02d_%02d", date.getYear(), date.getMonthValue(), date.getDayOfMonth())
+        }
+
+        /**
+         * Answers a string containing a concise, human-readable
+         * description of the receiver.
+         *
+         * @return String a printable representation for the receiver.
+         */
+        @Override
+        String toString() {
+            return "${createDateString(this.date)}_O_" +
+                    "${offerId.projectConservedPart}_${offerId.randomPart}_${offerId.version}" +
+                    ".pdf"
+        }
     }
 
 }


### PR DESCRIPTION
**Description of changes**
Addresses #685 by replacing the PDF Prefix "Q" with the Offer Prefix "O" in the offer pdf file name. 
Additionally, it removes the "v" before the <offer_version> in the offer pdf filename.  

