### PR TITLE
Change price calculation to account for internal and external product prices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Include Offer ID Prefix in Offer PDF filename (`#685 <https://github.com/qbicsoftware/offer-manager-2-portlet/issues/685>`_)
 
+* Differentiate between internal and external product unit prices (`#713 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/713>`_)
+
 **Dependencies**
 
 * ``mysql:mysql-connector-java:8.0.24`` -> ``8.0.25``

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -256,11 +256,16 @@ class Offer {
      * @return The calculated overhead amount of the selected items.
      */
     double getOverheadSum() {
-        double overheadSum = 0
-        items.each {
-                overheadSum += it.quantity * it.product.unitPrice * this.overhead
-        }
-        return overheadSum
+        return items.sum {calculateItemOverhead(it)} as double
+    }
+
+    private double calculateItemNet(ProductItem item) {
+        double unitPrice = selectedCustomerAffiliation.category == AffiliationCategory.INTERNAL ? item.product.internalUnitPrice : item.product.externalUnitPrice
+        return unitPrice * item.quantity
+    }
+
+    private double calculateItemOverhead(ProductItem item) {
+        return calculateItemNet(item) * overhead
     }
 
 
@@ -275,7 +280,7 @@ class Offer {
         items.each {
             // No overheads are assigned for data storage and project management
             if (it.product instanceof DataStorage || it.product instanceof ProjectManagement) {
-                costNoOverheadItemsNet += it.quantity * it.product.unitPrice
+                costNoOverheadItemsNet += calculateItemNet(it)
             }
         }
         return costNoOverheadItemsNet
@@ -294,7 +299,7 @@ class Offer {
                 // No overheads are assigned for data storage and project management
             }
             else {
-                costOverheadItemsNet += it.quantity * it.product.unitPrice
+                costOverheadItemsNet += calculateItemOverhead(it)
             }
         }
         return costOverheadItemsNet
@@ -444,32 +449,7 @@ class Offer {
     }
 
     private double calculateNetPrice() {
-        double netPrice
-        switch (selectedCustomerAffiliation.category) {
-            case AffiliationCategory.INTERNAL:
-                netPrice = calculateInternalNetPrice()
-                break
-            default:
-                netPrice = calculateExternalNetPrice()
-                break
-        }
-        return netPrice
-    }
-
-    /**
-     * Calculates the net price based on the internal unit prices of the products in this offer
-     * @return the net price of the offer items
-     */
-    private double calculateInternalNetPrice() {
-        items.sum {item -> item.quantity * item.product.internalUnitPrice} as double
-    }
-
-    /**
-     * Calculates the net price based on the external unit prices of the products in this offer
-     * @return the net price of the offer items
-     */
-    private double calculateExternalNetPrice() {
-        items.sum {item -> item.quantity * item.product.externalUnitPrice} as double
+        return items.sum {calculateItemNet(it)} as double
     }
 
     private double determineOverhead() {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -1,17 +1,14 @@
 package life.qbic.business.offers
 
 import groovy.time.TimeCategory
+import life.qbic.business.offers.Offer
+import life.qbic.business.offers.identifier.OfferId
 import life.qbic.business.offers.identifier.ProjectPart
 import life.qbic.business.offers.identifier.RandomPart
 import life.qbic.business.offers.identifier.Version
-import life.qbic.datamodel.dtos.business.Affiliation
-import life.qbic.datamodel.dtos.business.AffiliationCategory
-import life.qbic.datamodel.dtos.business.Customer
-import life.qbic.datamodel.dtos.business.ProductItem
-import life.qbic.datamodel.dtos.business.ProjectManager
+import life.qbic.datamodel.dtos.business.*
 import life.qbic.datamodel.dtos.business.services.DataStorage
 import life.qbic.datamodel.dtos.business.services.ProjectManagement
-import life.qbic.business.offers.identifier.OfferId
 import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
 
 import java.nio.charset.StandardCharsets
@@ -447,11 +444,30 @@ class Offer {
     }
 
     private double calculateNetPrice() {
-        double netSum = 0.0
-        for (item in items) {
-            netSum += item.quantity * item.product.unitPrice
+        switch (selectedCustomerAffiliation) {
+            case AffiliationCategory.INTERNAL:
+                return calculateInternalNetPrice()
+                break
+            default:
+                return calculateExternalNetPrice()
+                break
         }
-        return netSum
+    }
+
+    /**
+     * Calculates the net price based on the internal unit prices of the products in this offer
+     * @return the net price of the offer items
+     */
+    private double calculateInternalNetPrice() {
+        items.sum {item -> item.quantity * item.product.internalUnitPrice} as double
+    }
+
+    /**
+     * Calculates the net price based on the external unit prices of the products in this offer
+     * @return the net price of the offer items
+     */
+    private double calculateExternalNetPrice() {
+        items.sum {item -> item.quantity * item.product.externalUnitPrice} as double
     }
 
     private double determineOverhead() {
@@ -561,7 +577,7 @@ class Offer {
         StringBuilder sb = new StringBuilder()
         for(int i=0; i< bytes.length ;i++)
         {
-            sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
+            sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1))
         }
 
         //return complete hash

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -299,7 +299,7 @@ class Offer {
                 // No overheads are assigned for data storage and project management
             }
             else {
-                costOverheadItemsNet += calculateItemOverhead(it)
+                costOverheadItemsNet += calculateItemNet(it)
             }
         }
         return costOverheadItemsNet

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -444,14 +444,18 @@ class Offer {
     }
 
     private double calculateNetPrice() {
+        double netPrice
         switch (selectedCustomerAffiliation) {
             case AffiliationCategory.INTERNAL:
-                return calculateInternalNetPrice()
+                netPrice = calculateInternalNetPrice()
                 break
             default:
-                return calculateExternalNetPrice()
+                netPrice = calculateExternalNetPrice()
                 break
         }
+        // for backwards compatibility, we need to add the product item cost of product items that have no internal or external costs
+        netPrice += items.collect {it.product.unitPrice * it.quantity}.sum() as double
+        return netPrice
     }
 
     /**

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -453,8 +453,6 @@ class Offer {
                 netPrice = calculateExternalNetPrice()
                 break
         }
-        // for backwards compatibility, we need to add the product item cost of product items that have no internal or external costs
-        netPrice += items.collect {it.product.unitPrice * it.quantity}.sum() as double
         return netPrice
     }
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -486,6 +486,14 @@ class Offer {
     }
 
     /**
+     * Returns the sum of quantity discounts applied over all the items on this offer
+     * @return
+     */
+    double getQuantityDiscountSum() {
+        return items.collect {it.quantityDiscount}.sum() as double
+    }
+
+    /**
      * Determines if the customers affiliation is within germany
      * @return true if the country of the customer is within
      */

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -445,7 +445,7 @@ class Offer {
 
     private double calculateNetPrice() {
         double netPrice
-        switch (selectedCustomerAffiliation) {
+        switch (selectedCustomerAffiliation.category) {
             case AffiliationCategory.INTERNAL:
                 netPrice = calculateInternalNetPrice()
                 break

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/offers/Offer.groovy
@@ -7,8 +7,7 @@ import life.qbic.business.offers.identifier.ProjectPart
 import life.qbic.business.offers.identifier.RandomPart
 import life.qbic.business.offers.identifier.Version
 import life.qbic.datamodel.dtos.business.*
-import life.qbic.datamodel.dtos.business.services.DataStorage
-import life.qbic.datamodel.dtos.business.services.ProjectManagement
+import life.qbic.datamodel.dtos.business.services.*
 import life.qbic.datamodel.dtos.projectmanagement.ProjectIdentifier
 
 import java.nio.charset.StandardCharsets
@@ -25,6 +24,8 @@ import java.security.MessageDigest
  * @since 0.1.0
  */
 class Offer {
+    private static final QuantityDiscount QUANTITY_DISCOUNT = new QuantityDiscount();
+
     /**
      * Holds all available versions of an existing offer
      */
@@ -198,8 +199,7 @@ class Offer {
     private Offer(Builder builder) {
         this.customer = builder.customer
         this.identifier = builder.identifier
-        this.items = []
-        builder.items.each {this.items.add(it)}
+        importItems(builder.items)
         this.expirationDate = calculateExpirationDate(builder.creationDate)
         this.creationDate = builder.creationDate
         this.projectManager = builder.projectManager
@@ -564,5 +564,65 @@ class Offer {
 
         //return complete hash
         return sb.toString()
+    }
+
+    private void importItems(List<ProductItem> items) {
+        this.items.each {importItem(it)}
+    }
+
+    /**
+     * This method creates a new item based on the information in the provided item
+     * @param item
+     */
+    private void importItem(ProductItem item) {
+        ProductItem productItem = updateProductItem(item)
+        items.add(productItem)
+    }
+
+    /**
+     * This method calculates the quantity discount and total net price and returns an item with the associated information
+     * @param item
+     * @return a new item with additional information on discount and total net price
+     */
+    private ProductItem updateProductItem(ProductItem item) {
+        double totalPrice = calculateItemNet(item)
+        double quantityDiscount = 0.0
+        if (item.class in ProductGroup.DATA_ANALYSIS.associatedClasses) {
+            //assertion: quantity is integer
+            int quantity = item.quantity as int
+            quantityDiscount = QUANTITY_DISCOUNT.apply(quantity, totalPrice)
+        }
+        ProductItem productItem = new ProductItem(item.quantity, item.product, totalPrice, quantityDiscount)
+        return productItem
+    }
+
+    /**
+     * Possible product groups
+     *
+     * This enum describes the product groups into which the products of an offer are categorized.
+     * It also defines the acronyms used to abbreviate the product groups in the offer listings.
+     */
+    enum ProductGroup {
+        DATA_GENERATION("Data generation", "DG", [Sequencing, ProteomicAnalysis, MetabolomicAnalysis]),
+        DATA_ANALYSIS("Data analysis", "DA", [PrimaryAnalysis, SecondaryAnalysis]),
+        PROJECT_AND_DATA_MANAGEMENT("Project management & data storage", "PM & DS", [ProjectManagement, DataStorage])
+
+        private String groupName
+        private String acronym
+        private List<Class> associatedClasses
+
+        ProductGroup(String groupName, String acronym, List<Class> associatedClasses) {
+            this.groupName = groupName
+            this.acronym = acronym
+            this.associatedClasses = associatedClasses
+        }
+
+        String getName() {
+            return this.groupName
+        }
+
+        String getAcronym() {
+            return this.acronym
+        }
     }
 }

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -346,6 +346,9 @@ class OfferSpec extends Specification {
 
     }
 
+    /**
+     * @since 1.1.0
+     */
     def "the total net costs are computed with the correct external prices"() {
         given: "a list of product items with internal and external base prices"
         ProductItem primaryAnalysis = new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -93,9 +93,9 @@ class OfferSpec extends Specification {
         given: "A list of product items"
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ]
 
         and: "an internal offer containing these product items"
@@ -118,9 +118,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
+                " example", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.IMGAG)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-               "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+               "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.IMGAG))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -148,9 +148,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.PCT)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.PCT))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -178,9 +178,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1")),
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC)),
                 new ProductItem(1, new DataStorage("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_GIGABYTE, "1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_GIGABYTE, 1, Facility.QBIC))
 
         ]
 
@@ -199,9 +199,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE,"1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE,1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET,"1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET,1, Facility.QBIC))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -209,9 +209,9 @@ class OfferSpec extends Specification {
 
         List<ProductItem> items2 = [
                 new ProductItem(10, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE,"1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE,1, Facility.QBIC)),
                 new ProductItem(5, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET,"1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET,1, Facility.QBIC))
         ]
 
         Offer offer2 = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -228,9 +228,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE,"1")),
+                        " example", 1.0, 1.0,ProductUnit.PER_SAMPLE,1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET,"1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET,1, Facility.QBIC))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -250,9 +250,9 @@ class OfferSpec extends Specification {
         given:
         List<ProductItem> items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE,"1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE,1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET,"1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET,1, Facility.QBIC))
         ]
 
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -260,9 +260,9 @@ class OfferSpec extends Specification {
 
         List<ProductItem> items2 = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE,"1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE,1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET,"1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET,1, Facility.QBIC))
         ]
 
         Offer offer2 = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -279,15 +279,15 @@ class OfferSpec extends Specification {
     def "An Offer will provide methods to distinct between ProductItems associated with overhead costs and calculate their net sum"() {
         given:
         ProductItem primaryAnalysis = new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                " example primary analysis", 1.0, ProductUnit.PER_SAMPLE, "1"))
+                " example primary analysis", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem secondaryAnalysis = new ProductItem(1, new SecondaryAnalysis("Basic RNAsq", "Just an" +
-                " example secondary analysis", 2.0, ProductUnit.PER_SAMPLE, "1"))
+                " example secondary analysis", 2.0, 2.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem sequencing = new ProductItem(3, new Sequencing("Basic Sequencing", "Just an" +
-                "example sequencing", 3.0, ProductUnit.PER_SAMPLE, "1"))
+                "example sequencing", 3.0, 3.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem projectManagement = new ProductItem(1, new ProjectManagement("Basic Management",
-                "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ProductItem dataStorage = new ProductItem(2, new DataStorage("Data Storage",
-                "Just an example", 20.0, ProductUnit.PER_DATASET, "1"))
+                "Just an example", 20.0, 20.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
 
         List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
@@ -375,6 +375,74 @@ class OfferSpec extends Specification {
 
         where: "the affiliation is"
         affiliation << [externalAffiliation, externalAcademicAffiliation]
+    }
+
+    /**
+     * @since 1.1.0
+     */
+    def "the total overhead costs are computed with the correct internal prices"() {
+        given: "a list of product items with internal and external base prices"
+        ProductItem primaryAnalysis = new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
+                " example primary analysis", 2.5, 3.5, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem secondaryAnalysis = new ProductItem(1, new SecondaryAnalysis("Basic RNAsq", "Just an" +
+                " example secondary analysis", 2.4, 42.56, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem sequencing = new ProductItem(3, new Sequencing("Basic Sequencing", "Just an" +
+                "example sequencing", 3.0, 4.6, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem projectManagement = new ProductItem(1, new ProjectManagement("Basic Management",
+                "Just an example", 10.0, 11.26, ProductUnit.PER_DATASET, 1, Facility.QBIC))
+        ProductItem dataStorage = new ProductItem(2, new DataStorage("Data Storage",
+                "Just an example", 20.0, 23, ProductUnit.PER_DATASET, 1, Facility.QBIC))
+        and: "an offer with these items"
+        List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
+        Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
+                "awesome project", items, affiliation).build()
+        def netPrice
+
+        when: "the net price is calculated"
+        netPrice = offer.getOverheadSum()
+
+        then: "the correct prices are taken into account"
+        assert offer.selectedCustomerAffiliation.category == AffiliationCategory.INTERNAL
+        netPrice == items.sum {(it.quantity * it.product.internalUnitPrice)} as double * overheadRatio
+
+        where: "the affiliation is"
+        affiliation << [internalAffiliation]
+        overheadRatio = 0.0
+
+    }
+
+    /**
+     * @since 1.1.0
+     */
+    def "the total overhead costs are computed with the correct external prices"() {
+        given: "a list of product items with internal and external base prices"
+        ProductItem primaryAnalysis = new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
+                " example primary analysis", 2.5, 3.5, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem secondaryAnalysis = new ProductItem(1, new SecondaryAnalysis("Basic RNAsq", "Just an" +
+                " example secondary analysis", 2.4, 42.56, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem sequencing = new ProductItem(3, new Sequencing("Basic Sequencing", "Just an" +
+                "example sequencing", 3.0, 4.6, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
+        ProductItem projectManagement = new ProductItem(1, new ProjectManagement("Basic Management",
+                "Just an example", 10.0, 11.26, ProductUnit.PER_DATASET, 1, Facility.QBIC))
+        ProductItem dataStorage = new ProductItem(2, new DataStorage("Data Storage",
+                "Just an example", 20.0, 23, ProductUnit.PER_DATASET, 1, Facility.QBIC))
+        and: "an offer with these items"
+        List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
+        Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
+                "awesome project", items, affiliation).build()
+        def netPrice
+
+        when: "the net price is calculated"
+        netPrice = offer.getOverheadSum()
+
+        then: "the correct prices are taken into account"
+        assert offer.selectedCustomerAffiliation.category == AffiliationCategory.INTERNAL
+        netPrice == items.sum {(it.quantity * it.product.externalUnitPrice)} as double * overheadRatio
+
+        where: "the affiliation is"
+        affiliation | overheadRatio
+        externalAffiliation | 0.4
+        externalAcademicAffiliation | 0.2
 
     }
 }

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/OfferSpec.groovy
@@ -392,18 +392,17 @@ class OfferSpec extends Specification {
                 "Just an example", 10.0, 11.26, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ProductItem dataStorage = new ProductItem(2, new DataStorage("Data Storage",
                 "Just an example", 20.0, 23, ProductUnit.PER_DATASET, 1, Facility.QBIC))
-        and: "an offer with these items"
         List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
                 "awesome project", items, affiliation).build()
-        def netPrice
+        def overheadSum = 0
 
         when: "the net price is calculated"
-        netPrice = offer.getOverheadSum()
+        overheadSum = offer.getOverheadSum()
 
         then: "the correct prices are taken into account"
         assert offer.selectedCustomerAffiliation.category == AffiliationCategory.INTERNAL
-        netPrice == items.sum {(it.quantity * it.product.internalUnitPrice)} as double * overheadRatio
+        overheadSum == items.collect {return it.quantity * it.product.internalUnitPrice}.sum() * overheadRatio
 
         where: "the affiliation is"
         affiliation << [internalAffiliation]
@@ -430,14 +429,14 @@ class OfferSpec extends Specification {
         List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
         Offer offer = new Offer.Builder(customerWithAllAffiliations, projectManager, "Awesome Project", "An " +
                 "awesome project", items, affiliation).build()
-        def netPrice
+        def overheadSum = 0
 
         when: "the net price is calculated"
-        netPrice = offer.getOverheadSum()
+        overheadSum = offer.getOverheadSum()
 
         then: "the correct prices are taken into account"
-        assert offer.selectedCustomerAffiliation.category == AffiliationCategory.INTERNAL
-        netPrice == items.sum {(it.quantity * it.product.externalUnitPrice)} as double * overheadRatio
+        assert offer.selectedCustomerAffiliation.category == AffiliationCategory.EXTERNAL || offer.selectedCustomerAffiliation.category == AffiliationCategory.EXTERNAL_ACADEMIC
+        overheadSum == items.collect {return it.quantity * it.product.externalUnitPrice}.sum() * overheadRatio
 
         where: "the affiliation is"
         affiliation | overheadRatio

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/create/CreateOfferSpec.groovy
@@ -7,19 +7,9 @@ import life.qbic.business.offers.create.CreateOfferOutput
 import life.qbic.business.offers.identifier.ProjectPart
 import life.qbic.business.offers.identifier.RandomPart
 import life.qbic.business.offers.identifier.Version
-import life.qbic.datamodel.dtos.business.Affiliation
-import life.qbic.datamodel.dtos.business.AffiliationCategory
-import life.qbic.datamodel.dtos.business.Customer
-import life.qbic.datamodel.dtos.business.Offer
-import life.qbic.datamodel.dtos.business.OfferId
-import life.qbic.datamodel.dtos.business.ProductItem
-import life.qbic.datamodel.dtos.business.ProjectManager
-import life.qbic.datamodel.dtos.business.services.DataStorage
-import life.qbic.datamodel.dtos.business.services.PrimaryAnalysis
-import life.qbic.datamodel.dtos.business.services.ProductUnit
-import life.qbic.datamodel.dtos.business.services.ProjectManagement
-import life.qbic.datamodel.dtos.business.services.SecondaryAnalysis
-import life.qbic.datamodel.dtos.business.services.Sequencing
+import life.qbic.datamodel.dtos.business.*
+import life.qbic.datamodel.dtos.business.facilities.Facility
+import life.qbic.datamodel.dtos.business.services.*
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -70,7 +60,7 @@ class CreateOfferSpec extends Specification {
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
                         " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ]
 
         Offer offer = new Offer.Builder(customer, projectManager, projectTitle, projectDescription, selectedAffiliation)
@@ -90,8 +80,8 @@ class CreateOfferSpec extends Specification {
         CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)
 
         and:
-        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE, "1")),
-                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, ProductUnit.PER_SAMPLE, "1"))]
+        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, 1.4, ProductUnit.PER_SAMPLE, 1, Facility.QBIC)),
+                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",1.4, 1.4, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))]
         when:
         createOffer.calculatePrice(items, new Affiliation.Builder("Test", "", "", "")
                 .category(AffiliationCategory.INTERNAL).build())
@@ -106,8 +96,8 @@ class CreateOfferSpec extends Specification {
         CreateOffer createOffer = new CreateOffer(Stub(CreateOfferDataSource),output)
 
         and:
-        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, ProductUnit.PER_SAMPLE, "1")),
-                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, ProductUnit.PER_SAMPLE, "1"))]
+        List<ProductItem> items = [new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, 4, ProductUnit.PER_SAMPLE, 1, Facility.QBIC)),
+                                   new ProductItem(1,new Sequencing("This is a sequencing package", "a short description",4, 4, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))]
         when:
         createOffer.calculatePrice(items, new Affiliation.Builder("Test", "", "", "").country("France")
                 .category(AffiliationCategory.EXTERNAL).build())
@@ -120,15 +110,15 @@ class CreateOfferSpec extends Specification {
     def "Creating an Offer DTO from the Offer Entity works correctly"() {
         given:
         ProductItem primaryAnalysis = new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                " example primary analysis", 1.0, ProductUnit.PER_SAMPLE, "1"))
+                " example primary analysis", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem secondaryAnalysis = new ProductItem(1, new SecondaryAnalysis("Basic RNAsq", "Just an" +
-                " example secondary analysis", 2.0, ProductUnit.PER_SAMPLE, "1"))
+                " example secondary analysis", 2.0, 2.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem sequencing = new ProductItem(3, new Sequencing("Basic Sequencing", "Just an" +
-                "example sequencing", 3.0, ProductUnit.PER_SAMPLE, "1"))
+                "example sequencing", 3.0, 3.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC))
         ProductItem projectManagement = new ProductItem(1, new ProjectManagement("Basic Management",
-                "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ProductItem dataStorage = new ProductItem(2, new DataStorage("Data Storage",
-                "Just an example", 20.0, ProductUnit.PER_DATASET, "1"))
+                "Just an example", 20.0, 20.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         List<ProductItem> items = [primaryAnalysis, projectManagement, sequencing, dataStorage, secondaryAnalysis]
         life.qbic.business.offers.identifier.OfferId offerId = new life.qbic.business.offers.identifier.OfferId (new RandomPart(), new ProjectPart("test"), new Version(0))
         and:

--- a/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/fetch/FetchOfferSpec.groovy
+++ b/offer-manager-domain/src/test/groovy/life/qbic/portal/portlet/offers/fetch/FetchOfferSpec.groovy
@@ -4,18 +4,13 @@ import life.qbic.business.exceptions.DatabaseQueryException
 import life.qbic.business.offers.fetch.FetchOffer
 import life.qbic.business.offers.fetch.FetchOfferDataSource
 import life.qbic.business.offers.fetch.FetchOfferOutput
-import life.qbic.datamodel.dtos.business.Affiliation
-import life.qbic.datamodel.dtos.business.Customer
-import life.qbic.datamodel.dtos.business.Offer
-import life.qbic.datamodel.dtos.business.OfferId
-import life.qbic.datamodel.dtos.business.ProductItem
-import life.qbic.datamodel.dtos.business.ProjectManager
+import life.qbic.datamodel.dtos.business.*
+import life.qbic.datamodel.dtos.business.facilities.Facility
 import life.qbic.datamodel.dtos.business.services.PrimaryAnalysis
 import life.qbic.datamodel.dtos.business.services.ProductUnit
 import life.qbic.datamodel.dtos.business.services.ProjectManagement
 import spock.lang.Shared
 import spock.lang.Specification
-
 
 /**
  * This test class tests for the {@link life.qbic.business.offers.fetch.FetchOffer} use case functionality
@@ -56,9 +51,9 @@ class FetchOfferSpec extends Specification {
         projectDescription = "Cartoon Series"
         items = [
                 new ProductItem(2, new PrimaryAnalysis("Basic RNAsq", "Just an" +
-                        " example", 1.0, ProductUnit.PER_SAMPLE, "1")),
+                        " example", 1.0, 1.0, ProductUnit.PER_SAMPLE, 1, Facility.QBIC)),
                 new ProductItem(1, new ProjectManagement("Basic Management",
-                        "Just an example", 10.0, ProductUnit.PER_DATASET, "1"))
+                        "Just an example", 10.0, 10.0, ProductUnit.PER_DATASET, 1, Facility.QBIC))
         ]
         offerId = new OfferId("Conserved", "abcd", "2")
     }


### PR DESCRIPTION
Many thanks for contributing to this project!
Addresses #702 

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] Referenced issue is linked
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] `CHANGELOG.rst` is updated

**Description of changes**
This PR changes the net price calculation in the offer business object. This does not tackle any other computation and assumes that all net price calculation is based on the `calculateNetPrice` method in the Offer object.

For backwards compatibility the net price is now calculated using the internal or external prices + the unit prices.
It is assumed that the costs that are not provided are populated with `0.00`.
