### PR TITLE
Fix wrong product construction in factory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Offers without an experimental design can now be updated (`#726 <https://github.com/qbicsoftware/offer-manager-2-portlet/issue/726>`_)
 
+* Creating a product switches name and description (`#731 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/731>`_)
+
 **Dependencies**
 
 * ``mysql:mysql-connector-java:8.0.24`` -> ``8.0.25``

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -49,7 +49,7 @@ class MaintainProductsController {
      */
     void createNewProduct(ProductCategory category, String description, String name, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, Facility facility){
         try {
-            Product product = Converter.createProduct(category, description, name, internalUnitPrice, externalUnitPrice, unit, facility)
+            Product product = Converter.createProduct(category, name, description, internalUnitPrice, externalUnitPrice, unit, facility)
             createProductInput.create(product)
         } catch (Exception unexpected) {
             log.error("unexpected exception during create product call", unexpected)
@@ -84,7 +84,7 @@ class MaintainProductsController {
      */
     void copyProduct(ProductCategory category, String description, String name, double internalUnitPrice, double externalUnitPrice, ProductUnit unit, ProductId productId, Facility serviceProvider){
         try{
-            Product product = Converter.createProductWithVersion(category, description, name, internalUnitPrice, externalUnitPrice, unit, productId.uniqueId, serviceProvider)
+            Product product = Converter.createProductWithVersion(category, name, description, internalUnitPrice, externalUnitPrice, unit, productId.uniqueId, serviceProvider)
             copyProductInput.copyModified(product)
         }catch(Exception unexpected){
             log.error("Unexpected exception at copy product call", unexpected)


### PR DESCRIPTION
The factory was called with the wrong order of arguments leading to new products having description and title switched

Many thanks for contributing to this project!

**PR Checklist**
Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.rst` is updated

**Description of changes**
The product name and description were switched during product creation and copying.

**Technical details**
Changed the order to produce correct products.

![image](https://user-images.githubusercontent.com/11536497/127617579-0d542cfe-1f19-4164-98b3-136e64eabe13.png)

