### PR TITLE
Remove unknown enum constant

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/create/CreateAffiliationController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/create/CreateAffiliationController.groovy
@@ -41,11 +41,8 @@ class CreateAffiliationController {
         AffiliationCategoryFactory categoryFactory = new AffiliationCategoryFactory()
 
         AffiliationCategory affiliationCategory
-        if (!category || category?.isEmpty()) {
-            affiliationCategory = AffiliationCategory.UNKNOWN
-        } else {
-            affiliationCategory = categoryFactory.getForString(category)
-        }
+        assert category && ! category.isEmpty()
+        affiliationCategory = categoryFactory.getForString(category)
         affiliationBuilder.setCategory(affiliationCategory)
         Affiliation affiliation = affiliationBuilder.build()
         useCaseInput.createAffiliation(affiliation)


### PR DESCRIPTION
This PR removes the `AffiliationCategory.UNKNOWN` category which no longer exists. It assumes that the category string is not empty.
Addresses #538 