### PR TITLE
Adapt Spacing Of generated productItems to avoid overflow into the footer

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
@@ -186,10 +186,7 @@ class QuotationDetails {
         }
         //add product to current table
         htmlContent.getElementById(elementId).append(ItemPrintout.itemInHTML(itemNumber, item))
-        println("Current allocated Space" + consumedPageSpace)
-        println("Current item: " + item.productName + " " + determineItemSpace(item).toString())
         consumedPageSpace += determineItemSpace(item)
-        println("Space after Current Item" + consumedPageSpace)
     }
 
     /**
@@ -225,10 +222,7 @@ class QuotationDetails {
         String discountQuantity = Currency.getFormatterWithoutSymbol().format(item.getDiscountPerUnit())
 
         htmlContent.getElementById(elementId).append(ItemPrintout.discountItemInHTML(itemNumber, description, quantity, unit, unitDiscount, discountQuantity))
-        println("Current allocated Space" + consumedPageSpace)
-        println("Discount for: " + item.productName + " " + determineItemSpace("Discount", description, quantity, unit, unitDiscount, discountQuantity))
         consumedPageSpace += determineItemSpace("Discount", description, quantity, unit, unitDiscount, discountQuantity)
-        println("Space after Current Item" + consumedPageSpace)
     }
 
     private static String generateElementID(int tableCount, ProductGroup productGroups){
@@ -285,7 +279,6 @@ class QuotationDetails {
         double combinedPageSpace = descriptionPageSpace + facilityPageSpace
         calculatedSpaces.add(combinedPageSpace)
 
-        println(item.productName + " " +calculatedSpaces)
         return calculatedSpaces.max()
     }
 
@@ -304,7 +297,6 @@ class QuotationDetails {
         calculatedSpaces.add(minimalLineSpace + calculateItemSpace(unitPrice, ProductPropertySpacing.PRODUCT_UNIT_PRICE))
         calculatedSpaces.add(minimalLineSpace + calculateItemSpace(itemTotalCosts, ProductPropertySpacing.PRODUCT_TOTAL))
 
-        println(productName + " " + calculatedSpaces)
         return calculatedSpaces.max()
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
@@ -290,10 +290,10 @@ class QuotationDetails {
     private static double calculateItemSpace(String productProperty, ProductPropertySpacing productPropertySpacing) {
 
         //minimal lineSpace allocated for the item and the space underneath before any linebreaks occur
-        double minimalLineSpace = 0.5
+        double minimalItemLineSpace = 0.5
 
         // As soon as the PropertySpacing limit is reached a line break will occur
-        return minimalLineSpace + (Math.ceil(productProperty.length() / productPropertySpacing.getCharsLineLimit()) * lineSpace)
+        return minimalItemLineSpace + (Math.ceil(productProperty.length() / productPropertySpacing.getCharsLineLimit()) * lineSpace)
     }
 
     /**


### PR DESCRIPTION
**Description of changes**
This PR addresses the footer overflow introduced by the inclusion of discount productItems in the offer PDF. 

**Technical details**
This PR adds approximations for for the space per page to host the individual table elements. 
Additionally it removes the redundant subtable generation for the individual productGroup tables. 
Lastly the necessary space is now calculated before the page break is introduced to avoid cutoffs after the table title or table header but before the first item of a productGroup. 

**Additional context**
The values are now derived from manually measuring the space for each tableitem. However there is a slight variance since the linespace occupied by a linebreak in the productitem is bigger than the linebreak generated by the description(smaller fontsize)
This was tested manually with all current offers however, in which this change fixed the footer overflow for all of them. 