### PR TITLE
Release 1.1.0-rc2

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/offergeneration/QuotationDetails.groovy
@@ -206,7 +206,7 @@ class QuotationDetails {
         String quantity = item.quantity as String
         String unit = item.unit as String
         String unitDiscount = Currency.getFormatterWithoutSymbol().format(item.getDiscountPerUnit())
-        String discountQuantity = Currency.getFormatterWithoutSymbol().format(item.getDiscountPerUnit())
+        String discountQuantity = Currency.getFormatterWithoutSymbol().format(item.getQuantityDiscount())
 
         htmlContent.getElementById(elementId).append(ItemPrintout.discountItemInHTML(itemNumber, description, quantity, unit, unitDiscount, discountQuantity))
         consumedPageSpace += determineItemSpace("Discount", description, quantity, unit, unitDiscount, discountQuantity)
@@ -447,7 +447,7 @@ class QuotationDetails {
                         <div class="col-4 ">Discount</div>
                         <div class="col-1 price-value">${quantity}</div>
                         <div class="col-2 text-center">${unit}</div>
-                        <div class="col-2 price-value">${discountPerUnit}</div>
+                        <div class="col-2 price-value">-${discountPerUnit}</div>
                         <div class="col-2 price-value">-${quantityDiscount}</div>
                     </div>
                     <div class="row product-item">


### PR DESCRIPTION
1.1.0 (2021-08-17)
------------------

**Added**

* Function to apply the quantity discount price ( <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/707>)

* Adds a new DTO OfferItem which represents an item on the offer (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/728>)

* Display total quantity discount included in the offer in the offer overview (<https://github.com/qbicsoftware/offer-manager-2-portlet/issues/686>)

* Adds a new DTO OfferContent which represents the content of an offer (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/724>)

* Uses new DTOs instead of performing unnecessary computations in PDF creation (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/725>)

* Adds the CreateOfferContent use case (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/735>)

* Add discount unit and percentage to discount items, specify the discount item description (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/755>)

* Adds the total price before VAT is applied to an offer (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/754>)

**Fixed**

* Invert quantity discount in order to be able to display size of discount (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/710>)

* Include Offer ID Prefix in Offer PDF filename (<https://github.com/qbicsoftware/offer-manager-2-portlet/issues/685>)

* Differentiate between internal and external product unit prices (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/713>)

* Include internal and external prices as well as facilities in the products (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/712>)

* The internal and external product unit prices are shown in the user interface (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/723>)

* Reset the offer update view, when a new offer is selected in the offer overview (<https://github.com/qbicsoftware/offer-manager-2-portlet/issues/716>)

* Offers without an experimental design can now be updated (<https://github.com/qbicsoftware/offer-manager-2-portlet/issues/726>)

* Creating a product switches name and description (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/731>)

* Space names are now validated (<https://github.com/qbicsoftware/offer-manager-2-portlet/pull/736>)

**Dependencies**

* ``mysql:mysql-connector-java:8.0.24`` -> ``8.0.25``

* ``org.mariadb.jdbc:mariadb-java-client:2.7.2`` -> ``2.7.3``

* ``life.qbic:data-model-lib:2.8.2`` -> ``2.11.0``

**Deprecated**
