### PR TITLE
FileDownloaders are not removed if they are not added first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 * Fix rounding issue for discount unit price (`#784 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/784>`_)
 
+* Fix app trying to unregister file downloaders that were not previously registered (`#796 <https://github.com/qbicsoftware/offer-manager-2-portlet/pull/796>`_)
+
 **Dependencies**
 
 * ``mysql:mysql-connector-java:8.0.24`` -> ``8.0.25``

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/OfferOverviewView.groovy
@@ -231,9 +231,11 @@ class OfferOverviewView extends VerticalLayout {
     }
 
     private void removeExistingResources() {
-        if (fileDownloader) {
-            downloadBtn.removeExtension(fileDownloader)
-        }
+        Optional.ofNullable(fileDownloader).ifPresent({
+            if (downloadBtn.extensions.contains(fileDownloader)) {
+                downloadBtn.removeExtension(fileDownloader)
+            }
+        })
     }
 
     private class LoadOfferInfoThread extends Thread {


### PR DESCRIPTION
Check before removing an extension whether the extension is there or not.