### PR TITLE
Upgrade vaadin to security fixed version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.1 (2021-10-27)
+------------------
+
+**Added**
+
+**Fixed**
+
+**Dependencies**
+
+* com.vaadin 8.13.0 -> 8.14.0 (addresses CVE-2021-37714)
+
+**Deprecated**
+
 1.2.0 (2021-10-13)
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
 		<groovy.version>3.0.8</groovy.version>
 
-		<vaadin.version>8.13.0</vaadin.version>
-		<vaadin.plugin.version>8.13.0</vaadin.plugin.version>
+		<vaadin.version>8.14.0</vaadin.version>
+		<vaadin.plugin.version>8.14.0</vaadin.plugin.version>
 	</properties>
 	<pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
fixes security issue by upgrading to vaadin 8.14.0

(see [https://vaadin.com/security/2021-10-27](https://vaadin.com/security/2021-10-27?utm_campaign=Vaadin%20Security%20Advisories&utm_medium=email&_hsmi=175586367&_hsenc=p2ANqtz-8PMPMYTOuz-UKhxeS3YnoJmQBuh2XvbeJtNPGwqIAD3Kv1gCU2RCqcl2vHGNhPlOhnfS_KEqfWpJxPdNLSZxeLu9_PFvvq84MGKFwl1PosysPMzOc&utm_content=175586367&utm_source=hs_email))