### PR TITLE
Hotfix 1.2.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ Changelog
 
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
+1.2.6 (2022-01-04)
+------------------
+
+**Added**
+
+**Fixed**
+
+* CVE-2021-44832
+
+**Dependencies**
+
+* ``org.apache.logging.log4j:log4j-core:2.17.0`` -> ``2.17.1``
+* ``org.apache.logging.log4j:log4j-api:2.17.0`` -> ``2.17.1``
+
+**Deprecated**
+
 1.2.5 (2021-12-21)
 ------------------
 

--- a/offer-manager-app/pom.xml
+++ b/offer-manager-app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>offer-manager</artifactId>
         <groupId>life.qbic</groupId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>life.qbic</groupId>
             <artifactId>offer-manager-domain</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/offer-manager-domain/pom.xml
+++ b/offer-manager-domain/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>offer-manager</artifactId>
 		<groupId>life.qbic</groupId>
-		<version>1.2.5</version>
+		<version>1.2.6</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<module>offer-manager-app</module>
 	</modules>
 	<artifactId>offer-manager</artifactId>
-	<version>1.2.5</version> <!-- <<QUBE_FORCE_BUMP>> -->
+	<version>1.2.6</version>
 	<groupId>life.qbic</groupId>
 	<name>The new offer manager</name>
 	<url>https://github.com/qbicsoftware/qOffer_2.0</url>
@@ -24,7 +24,7 @@
 		<vaadin.version>8.14.3</vaadin.version>
 		<vaadin.plugin.version>8.14.3</vaadin.plugin.version>
 
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 	<pluginRepositories>
 		<pluginRepository>


### PR DESCRIPTION
1.2.6 (2022-01-04)
------------------

**Added**

**Fixed**

* CVE-2021-44832

**Dependencies**

* ``org.apache.logging.log4j:log4j-core:2.17.0`` -> ``2.17.1``
* ``org.apache.logging.log4j:log4j-api:2.17.0`` -> ``2.17.1``

**Deprecated**