### PR TITLE
Enable scrollbar for mainview for smaller screensizes

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/AppView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/AppView.groovy
@@ -62,6 +62,8 @@ class AppView extends VerticalLayout {
         registerListeners()
         setupFeatureViews()
         hideAllFeatureViews()
+        makeAppViewScrollable()
+
         /*
          We set the offer overview view as first active view.
          You can set any other view to visible here for the startup
@@ -170,6 +172,12 @@ class AppView extends VerticalLayout {
         }
     }
 
+    private void makeAppViewScrollable () {
+        this.setWidth("100%");
+        this.setHeight("100%");
+        this.addStyleName("scrollable-layout")
+    }
+
     private class TomatoFeatures extends HorizontalLayout {
 
         TomatoFeatures() {
@@ -216,5 +224,6 @@ class AppView extends VerticalLayout {
             return dropDownButton
         }
 
-    }
+      }
+
 }

--- a/offer-manager-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
+++ b/offer-manager-app/src/main/webapp/VAADIN/themes/mytheme/mytheme.scss
@@ -45,4 +45,8 @@
     text-align: right;
     padding-top: 50px;
   }
+
+  .scrollable-layout {
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
Addresses [DM-216](https://qbicsoftware.atlassian.net/jira/software/c/projects/DM/boards/4?modal=detail&selectedIssue=DM-216) by ensuring that the mainview is scrollable via scollbars if the screensize is too small to host the entire view. 

You can test this functionality yourself on [portal-testing](https://portal-testing.qbic.uni-tuebingen.de/web/guest/offer-manager-development-).








