### PR TITLE
Re-use previously selected space in project creation

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/projectcreation/CreateProjectView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/projectcreation/CreateProjectView.groovy
@@ -320,6 +320,7 @@ class CreateProjectView extends VerticalLayout{
     }
 
     private void resetInputs() {
+        String previousSpaceName = new String(resultingSpaceName.getValue())
         this.projectSpaceSelection.clear()
         this.desiredProjectCode.clear()
         this.resultingProjectCode.clear()
@@ -328,6 +329,7 @@ class CreateProjectView extends VerticalLayout{
         this.existingSpaceLayout.setVisible(false)
         this.customSpaceLayout.setVisible(false)
         this.projectAvailability.removeAllComponents()
+        resultingSpaceName.setValue(previousSpaceName)
     }
 
     private void bindData() {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/projectcreation/CreateProjectViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/overview/projectcreation/CreateProjectViewModel.groovy
@@ -118,7 +118,10 @@ class CreateProjectViewModel {
     }
 
     private void resetModel() {
+        String previousSpace = new String(resultingSpaceName)
         initFields()
+        resultingSpaceName = previousSpace
+        desiredSpaceName = previousSpace
     }
     
     private void validateSpaceName() {


### PR DESCRIPTION
Addresses a bug report from a user, that for
repeating project creation in the same space, the space name
was not saved from the previously generated project ID.

This commit will save the last space name used in the project
creation and re-use it, to increase effectivity during
recurring project creation within the same space.