### PR TITLE
Ask for confirmation if an affilation category was changed during Affiliation Update

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -1,6 +1,5 @@
 package life.qbic.portal.offermanager.components.affiliation.update
 
-
 import com.vaadin.icons.VaadinIcons
 import com.vaadin.shared.ui.ContentMode
 import com.vaadin.ui.*
@@ -28,8 +27,6 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
   private AffiliationUserInput affiliationFormView
   private String unexpectedErrorMessage = "An unexpected error occurred. We apologize for any inconveniences. Please inform us via email to $Constants.QBIC_HELPDESK_EMAIL"
 
-  private boolean categoryChangeConfirmed = false
-
   UpdateAffiliationView(AppViewModel sharedViewModel, UpdateAffiliationController controller, ResourcesService<life.qbic.datamodel.dtos.business.Affiliation> affiliationResourcesService) {
     this.sharedViewModel = sharedViewModel
     this.controller = controller
@@ -44,7 +41,6 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
   void reset() {
     affiliationFormView.reset()
     outdatedAffiliation = null
-    categoryChangeConfirmed = false
   }
 
   @Override

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -102,6 +102,11 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
     if (isAffiliationCategoryChanged(affiliation)) {
       ConfirmAffiliationChangeWindow confirmAffiliationChangeWindow = new ConfirmAffiliationChangeWindow()
       this.getUI().addWindow(confirmAffiliationChangeWindow)
+      confirmAffiliationChangeWindow.addCloseListener(it -> {
+        if (confirmAffiliationChangeWindow.wasConfirmed()) {
+          triggerAffiliationUpdate(affiliation)
+        }
+      })
     } else {
       triggerAffiliationUpdate(affiliation)
     }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -98,6 +98,7 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
   private void onSubmit() {
     Affiliation affiliation = affiliationFormView.get()
     //todo make sure changes in country and category are confirmed again by the user
+    confirmAffiliationCategoryChange(affiliation)
     affiliation.setId(outdatedAffiliation.getId())
     this.controller.updateAffiliation(affiliation)
     fireUpdateSubmitted()
@@ -130,6 +131,16 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
         log.error(unexpectedErrorMessage, unexpectedException)
         sharedViewModel.failureNotifications.add(unexpectedErrorMessage)
       }
+    }
+  }
+
+  private boolean isAffiliationCategoryChangeConfirmed(Affiliation affiliation) {
+    boolean affiliationCategoryChangeConfirmed
+    if (affiliation.getCategory().equals(outdatedAffiliation.getCategory())) {
+      //ToDo Generate Popup asking for confirmation
+      //ToDo Listen on Button in Popup and set Boolean
+      //toDo Return Boolean and adapt controller to only be triggered if boolean == true
+
     }
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -185,7 +185,7 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
     }
 
     private void setupButtons() {
-      this.abortButton = new Button("Abort Affiliation Update")
+      this.abortButton = new Button("Back to editing!")
       this.abortButton.setIcon(VaadinIcons.CLOSE_CIRCLE)
       this.abortButton.addStyleName(ValoTheme.BUTTON_DANGER)
       this.submitButton = new Button("Confirm Affiliation Update")

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -1,5 +1,6 @@
 package life.qbic.portal.offermanager.components.affiliation.update
 
+
 import com.vaadin.icons.VaadinIcons
 import com.vaadin.shared.ui.ContentMode
 import com.vaadin.ui.*
@@ -99,7 +100,7 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
     Affiliation affiliation = affiliationFormView.get()
     affiliation.setId(outdatedAffiliation.getId())
     if (isAffiliationCategoryChanged(affiliation)) {
-      ConfirmAffiliationChangeWindow confirmAffiliationChangeWindow = new ConfirmAffiliationChangeWindow(affiliation)
+      ConfirmAffiliationChangeWindow confirmAffiliationChangeWindow = new ConfirmAffiliationChangeWindow()
       this.getUI().addWindow(confirmAffiliationChangeWindow)
     } else {
       triggerAffiliationUpdate(affiliation)
@@ -153,10 +154,9 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
   private class ConfirmAffiliationChangeWindow extends Window {
     private Button abortButton
     private Button submitButton
-    private Affiliation updatedAffiliation
+    boolean answer = false
 
-    ConfirmAffiliationChangeWindow(Affiliation affiliation) {
-      this.updatedAffiliation = affiliation
+    ConfirmAffiliationChangeWindow() {
       generateAffiliationChangeWindow()
     }
 
@@ -214,12 +214,17 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
     }
 
     private void onSubmit() {
-      triggerAffiliationUpdate(updatedAffiliation)
+      answer = true
       this.close()
     }
 
     private void onAbort() {
+      answer = false
       this.close()
+    }
+
+    boolean wasConfirmed() {
+      return answer
     }
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/update/UpdateAffiliationView.groovy
@@ -185,10 +185,10 @@ class UpdateAffiliationView extends FormLayout implements Resettable, Updatable<
     }
 
     private void setupButtons() {
-      this.abortButton = new Button("Back to editing!")
+      this.abortButton = new Button("Back to Editing")
       this.abortButton.setIcon(VaadinIcons.CLOSE_CIRCLE)
       this.abortButton.addStyleName(ValoTheme.BUTTON_DANGER)
-      this.submitButton = new Button("Confirm Affiliation Update")
+      this.submitButton = new Button("Update Affiliation")
       this.submitButton.setIcon(VaadinIcons.OFFICE)
       this.submitButton.addStyleName(ValoTheme.BUTTON_FRIENDLY)
     }


### PR DESCRIPTION
**Introduced Feature**
Introduces a modal popup window asking for confirmation if an affiliation category was changed during the affiliation update. 

**How To Test**
1. Select an Affiliation in the searchAffiliationView
2. Update the selected Affiliation with a new Affiliation Category 
3. Click the Update Affiliation Button
4. Observe the shiny new popupWindow asking the user for confirmation
5. Press the Update Affillation Button in the Popup Window
6. Oberve the updated Affiliation in the affiliation Overview.