### PR TITLE
Fix error storing new products from outside QBiC

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/product/MaintainProductsController.groovy
@@ -49,7 +49,7 @@ class MaintainProductsController {
         RefactorConverter converter = new RefactorConverter()
         try {
             ProductDraft productDraft = ProductDraft.create(converter.toProductCategory(category),
-                    name, description, internalUnitPrice, externalUnitPrice, unit.value, facility.getLabel())
+                    name, description, internalUnitPrice, externalUnitPrice, unit.value, facility.name())
             createProductInput.create(productDraft)
         } catch (Exception unexpected) {
             log.error("unexpected exception during create product call", unexpected)


### PR DESCRIPTION
This PR changes product storage to correctly store the enum name instead of the facility label.
