### PR TITLE
Replace current UpdateOfferView with Framework for new GridLayout

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
@@ -1,10 +1,7 @@
 package life.qbic.portal.offermanager.components.offer.update
 
 import com.vaadin.shared.ui.MarginInfo
-import com.vaadin.ui.GridLayout
-import com.vaadin.ui.HorizontalLayout
-import com.vaadin.ui.Label
-import com.vaadin.ui.VerticalLayout
+import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
 import life.qbic.portal.offermanager.components.AppViewModel
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationView
@@ -33,7 +30,7 @@ class UpdateOfferView extends VerticalLayout {
   //ToDo Remove View once content is wired into ProjectInformationLayout
   private final ProjectInformationView projectInformationView
 
-  //ToDo Wire information into each Layout and style layouts
+  //ToDo Wire information into each Layout and finalize layout style
   private GridLayout contentGridLayout
   private ProjectInformationLayout projectInformationLayout
   private SelectCustomerLayout selectCustomerLayout
@@ -72,6 +69,7 @@ class UpdateOfferView extends VerticalLayout {
     initMainLayout()
     initSubLayouts()
     positionSubLayouts()
+    styleSubLayouts()
     this.addComponent(contentGridLayout)
   }
 
@@ -86,24 +84,20 @@ class UpdateOfferView extends VerticalLayout {
     this.setMargin(false)
     this.setSpacing(false)
   }
+
   /**
    * See https://miro.com/app/board/uXjVO4E_5wc=/ for explanation of Grid sections
    */
-
   private void initSubLayouts() {
-    //Todo Implement Layout Styling and Alignment
     contentGridLayout = new GridLayout(3, 6)
     projectInformationLayout = new ProjectInformationLayout()
     selectCustomerLayout = new SelectCustomerLayout()
     selectProjectManagerLayout = new SelectProjectManagerLayout()
     offerDetailsHeaderLayout = new HorizontalLayout()
-    //Todo Move margins to custom CSS?
     offerDetailsHeaderLayout.addComponent(new Label("Offer Details:"))
-    offerDetailsHeaderLayout.setMargin(new MarginInfo(false, false, false, true))
     pricingLayout = new PricingLayout()
     productItemsLayout = new ProductItemsLayout()
     submissionButtonBarLayout = new SubmissionButtonBarLayout()
-    contentGridLayout.setSizeFull()
   }
 
   private void positionSubLayouts() {
@@ -115,6 +109,16 @@ class UpdateOfferView extends VerticalLayout {
     contentGridLayout.addComponent(pricingLayout, 1, 3)
     contentGridLayout.addComponent(productItemsLayout, 0, 4, 2, 4)
     contentGridLayout.addComponent(submissionButtonBarLayout, 2, 5)
+  }
+
+  private void styleSubLayouts() {
+    contentGridLayout.setComponentAlignment(submissionButtonBarLayout, Alignment.BOTTOM_RIGHT)
+    contentGridLayout.setComponentAlignment(pricingLayout, Alignment.BOTTOM_RIGHT)
+    contentGridLayout.setColumnExpandRatio(0, 0.5)
+    contentGridLayout.setColumnExpandRatio(1, 0.2)
+    contentGridLayout.setColumnExpandRatio(2, 0.2)
+    contentGridLayout.setSizeFull()
+    offerDetailsHeaderLayout.setMargin(new MarginInfo(false, false, false, true))
   }
 
   void resetLayoutContent() {

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
@@ -1,10 +1,15 @@
 package life.qbic.portal.offermanager.components.offer.update
 
-import com.vaadin.ui.*
+import com.vaadin.shared.ui.MarginInfo
+import com.vaadin.ui.GridLayout
+import com.vaadin.ui.HorizontalLayout
+import com.vaadin.ui.Label
+import com.vaadin.ui.VerticalLayout
 import com.vaadin.ui.themes.ValoTheme
 import life.qbic.portal.offermanager.components.AppViewModel
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationView
 import life.qbic.portal.offermanager.components.offer.create.*
+import life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts.*
 import life.qbic.portal.offermanager.components.person.create.CreatePersonView
 import life.qbic.portal.offermanager.components.person.update.UpdatePersonView
 
@@ -25,18 +30,18 @@ class UpdateOfferView extends VerticalLayout {
 
   private final UpdateOfferController controller
 
-  //ToDo Remove Views once Layout is written
+  //ToDo Remove View once content is wired into ProjectInformationLayout
   private final ProjectInformationView projectInformationView
 
-  //ToDo Add Layouts for each View below for UpdateOfferMainView
+  //ToDo Wire information into each Layout and style layouts
   private GridLayout contentGridLayout
-  private VerticalLayout projectInformationLayout
-  private VerticalLayout customerInformationLayout
-  private VerticalLayout projectManagerLayout
-  private VerticalLayout pricingLayout
-  private HorizontalLayout productItemsLayout
-  private HorizontalLayout cancelSubmissionButtonBarLayout
-
+  private ProjectInformationLayout projectInformationLayout
+  private SelectCustomerLayout selectCustomerLayout
+  private SelectProjectManagerLayout selectProjectManagerLayout
+  private HorizontalLayout offerDetailsHeaderLayout
+  private PricingLayout pricingLayout
+  private ProductItemsLayout productItemsLayout
+  private SubmissionButtonBarLayout submissionButtonBarLayout
 
   private final CustomerSelectionView customerSelectionView
   private final ProjectManagerSelectionView projectManagerSelectionView
@@ -56,19 +61,17 @@ class UpdateOfferView extends VerticalLayout {
     this.sharedViewModel = sharedViewModel
     this.viewModel = updateOfferViewModel
     this.controller = controller
-    //ToDo Wire View Navigation into button functionality of MainView
+    //ToDo Wire View Navigation to each view into the buttons of the updateOfferView
     this.createCustomerView = createCustomerView
     this.updatePersonView = updatePersonView
     this.createAffiliationView = createAffiliationView
-    //ToDo Replace View with Layout
     this.projectInformationView = new ProjectInformationView(viewModel)
     this.customerSelectionView = new CustomerSelectionView(viewModel)
     this.projectManagerSelectionView = new ProjectManagerSelectionView(viewModel)
     this.selectItemsView = new SelectItemsView(viewModel, sharedViewModel)
-    //ToDo Include OverViewView Layout with Pricing for MainView
     initMainLayout()
     initSubLayouts()
-    positionLayoutsInMainLayout()
+    positionSubLayouts()
     this.addComponent(contentGridLayout)
   }
 
@@ -83,38 +86,38 @@ class UpdateOfferView extends VerticalLayout {
     this.setMargin(false)
     this.setSpacing(false)
   }
+  /**
+   * See https://miro.com/app/board/uXjVO4E_5wc=/ for explanation of Grid sections
+   */
 
   private void initSubLayouts() {
-    //ToDo Implement SubLayouts initialization for MainLayout
-    contentGridLayout = new GridLayout(2, 6)
-    projectInformationLayout = new VerticalLayout()
-    projectInformationLayout.addComponent(new Button("ProjectInformationArea"))
-    customerInformationLayout = new VerticalLayout()
-    customerInformationLayout.addComponent(new Button("CustomerInformationArea"))
-    projectManagerLayout = new VerticalLayout()
-    projectManagerLayout.addComponent(new Button("ProjectManagerArea"))
-    pricingLayout = new VerticalLayout()
-    pricingLayout.addComponent(new Button("PricingInformationArea"))
-    productItemsLayout = new HorizontalLayout()
-    productItemsLayout.addComponent(new Button("ProductItemsArea"))
-    cancelSubmissionButtonBarLayout = new HorizontalLayout()
-    cancelSubmissionButtonBarLayout.addComponent(new Button("SubmissionCancelArea"))
-    contentGridLayout.setWidthFull()
-    contentGridLayout.setHeightFull()
+    //Todo Implement Layout Styling and Alignment
+    contentGridLayout = new GridLayout(3, 6)
+    projectInformationLayout = new ProjectInformationLayout()
+    selectCustomerLayout = new SelectCustomerLayout()
+    selectProjectManagerLayout = new SelectProjectManagerLayout()
+    offerDetailsHeaderLayout = new HorizontalLayout()
+    //Todo Move margins to custom CSS?
+    offerDetailsHeaderLayout.addComponent(new Label("Offer Details:"))
+    offerDetailsHeaderLayout.setMargin(new MarginInfo(false, false, false, true))
+    pricingLayout = new PricingLayout()
+    productItemsLayout = new ProductItemsLayout()
+    submissionButtonBarLayout = new SubmissionButtonBarLayout()
+    contentGridLayout.setSizeFull()
   }
 
-  void positionLayoutsInMainLayout() {
-    //Todo Replace View with Layout
-    contentGridLayout.addComponent(projectInformationView, 0, 0, 0, 1)
-    contentGridLayout.addComponent(customerInformationLayout, 1, 1)
-    contentGridLayout.addComponent(projectManagerLayout, 1, 2)
+  private void positionSubLayouts() {
+
+    contentGridLayout.addComponent(projectInformationLayout, 0, 0, 1, 1)
+    contentGridLayout.addComponent(selectCustomerLayout, 2, 0)
+    contentGridLayout.addComponent(selectProjectManagerLayout, 2, 1)
+    contentGridLayout.addComponent(offerDetailsHeaderLayout, 0, 2)
     contentGridLayout.addComponent(pricingLayout, 1, 3)
-    //ToDo extract relevant view from layout
-    contentGridLayout.addComponent(selectItemsView, 0, 4, 1, 4)
-    contentGridLayout.addComponent(cancelSubmissionButtonBarLayout, 1, 5)
+    contentGridLayout.addComponent(productItemsLayout, 0, 4, 2, 4)
+    contentGridLayout.addComponent(submissionButtonBarLayout, 2, 5)
   }
 
-  void resetViewContent() {
+  void resetLayoutContent() {
     //ToDo Reset Content of all Layouts and Views
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferView.groovy
@@ -1,10 +1,7 @@
 package life.qbic.portal.offermanager.components.offer.update
 
-import com.vaadin.ui.Component
-import com.vaadin.ui.FormLayout
-import com.vaadin.ui.Label
+import com.vaadin.ui.*
 import com.vaadin.ui.themes.ValoTheme
-import life.qbic.datamodel.dtos.business.ProductItem
 import life.qbic.portal.offermanager.components.AppViewModel
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationView
 import life.qbic.portal.offermanager.components.offer.create.*
@@ -15,278 +12,109 @@ import life.qbic.portal.offermanager.components.person.update.UpdatePersonView
  * This class generates a Layout in which the user
  * can input the necessary information for the creation of a new offer
  *
- * CreateOfferView will be integrated into the qOffer 2.0 Portlet and provides an User Interface
- * with the intention of enabling a user the creation of a new Offer in the QBiC Database
+ * UpdateOfferView will be integrated into the qOffer 2.0 Portlet and provides an User Interface
+ * with the intention of enabling a user the creation of an updated version of an already stored Offer in the QBiC Database
  *
- * @since: 0.1.0
+ * @since: 1.6.0
  *
  */
-class UpdateOfferView extends FormLayout {
+class UpdateOfferView extends VerticalLayout {
 
-    final private AppViewModel sharedViewModel
-    final CreateOfferViewModel viewModel
+  final private AppViewModel sharedViewModel
+  final CreateOfferViewModel viewModel
 
-    private final UpdateOfferController controller
+  private final UpdateOfferController controller
 
-    private final ProjectInformationView projectInformationView
-    private final CustomerSelectionView customerSelectionView
-    private final ProjectManagerSelectionView projectManagerSelectionView
-    private final SelectItemsView selectItemsView
-    private final OfferOverviewView overviewView
+  //ToDo Remove Views once Layout is written
+  private final ProjectInformationView projectInformationView
 
-    private final CreatePersonView createCustomerView
-    private final UpdatePersonView updatePersonView
-    private ButtonNavigationView navigationView
-    private final CreateAffiliationView createAffiliationView
+  //ToDo Add Layouts for each View below for UpdateOfferMainView
+  private GridLayout contentGridLayout
+  private VerticalLayout projectInformationLayout
+  private VerticalLayout customerInformationLayout
+  private VerticalLayout projectManagerLayout
+  private VerticalLayout pricingLayout
+  private HorizontalLayout productItemsLayout
+  private HorizontalLayout cancelSubmissionButtonBarLayout
 
-    private final ViewHistory viewHistory
 
+  private final CustomerSelectionView customerSelectionView
+  private final ProjectManagerSelectionView projectManagerSelectionView
+  private final SelectItemsView selectItemsView
 
-    UpdateOfferView(AppViewModel sharedViewModel,
-                    UpdateOfferViewModel updateOfferViewModel,
-                    UpdateOfferController controller,
-                    CreatePersonView createCustomerView,
-                    CreateAffiliationView createAffiliationView,
-                    UpdatePersonView updatePersonView) {
-        super()
-        this.sharedViewModel = sharedViewModel
-        this.viewModel = updateOfferViewModel
-        this.controller = controller
-        this.createCustomerView = createCustomerView
-        this.updatePersonView = updatePersonView
-        this.createAffiliationView = createAffiliationView
-        this.projectInformationView = new ProjectInformationView(viewModel)
-        this.customerSelectionView = new CustomerSelectionView(viewModel)
+  private final CreatePersonView createCustomerView
+  private final UpdatePersonView updatePersonView
+  private final CreateAffiliationView createAffiliationView
 
-        this.projectManagerSelectionView = new ProjectManagerSelectionView(viewModel)
-        this.selectItemsView = new SelectItemsView(viewModel, sharedViewModel)
-        this.overviewView = new OfferOverviewView(viewModel)
+  UpdateOfferView(AppViewModel sharedViewModel,
+                  UpdateOfferViewModel updateOfferViewModel,
+                  UpdateOfferController controller,
+                  CreatePersonView createCustomerView,
+                  CreateAffiliationView createAffiliationView,
+                  UpdatePersonView updatePersonView) {
+    super()
+    this.sharedViewModel = sharedViewModel
+    this.viewModel = updateOfferViewModel
+    this.controller = controller
+    //ToDo Wire View Navigation into button functionality of MainView
+    this.createCustomerView = createCustomerView
+    this.updatePersonView = updatePersonView
+    this.createAffiliationView = createAffiliationView
+    //ToDo Replace View with Layout
+    this.projectInformationView = new ProjectInformationView(viewModel)
+    this.customerSelectionView = new CustomerSelectionView(viewModel)
+    this.projectManagerSelectionView = new ProjectManagerSelectionView(viewModel)
+    this.selectItemsView = new SelectItemsView(viewModel, sharedViewModel)
+    //ToDo Include OverViewView Layout with Pricing for MainView
+    initMainLayout()
+    initSubLayouts()
+    positionLayoutsInMainLayout()
+    this.addComponent(contentGridLayout)
+  }
 
-        initLayout()
-        registerListeners()
+  /**
+   * Initializes the view with the ProjectInformationView, which is the first component to be shown
+   */
+  private void initMainLayout() {
+    final Label label = new Label("Update Offer")
+    label.addStyleName(ValoTheme.LABEL_HUGE)
+    this.addComponent(label)
+    this.setSizeFull()
+    this.setMargin(false)
+    this.setSpacing(false)
+  }
 
-        // add all step views to the main view
-        addStepViewsToCurrent()
-        // hide all views
-        hideViews()
+  private void initSubLayouts() {
+    //ToDo Implement SubLayouts initialization for MainLayout
+    contentGridLayout = new GridLayout(2, 6)
+    projectInformationLayout = new VerticalLayout()
+    projectInformationLayout.addComponent(new Button("ProjectInformationArea"))
+    customerInformationLayout = new VerticalLayout()
+    customerInformationLayout.addComponent(new Button("CustomerInformationArea"))
+    projectManagerLayout = new VerticalLayout()
+    projectManagerLayout.addComponent(new Button("ProjectManagerArea"))
+    pricingLayout = new VerticalLayout()
+    pricingLayout.addComponent(new Button("PricingInformationArea"))
+    productItemsLayout = new HorizontalLayout()
+    productItemsLayout.addComponent(new Button("ProductItemsArea"))
+    cancelSubmissionButtonBarLayout = new HorizontalLayout()
+    cancelSubmissionButtonBarLayout.addComponent(new Button("SubmissionCancelArea"))
+    contentGridLayout.setWidthFull()
+    contentGridLayout.setHeightFull()
+  }
 
-        // Init the view navigation history to be able to navigate back in history
-        this.viewHistory = new ViewHistory(projectInformationView)
-    }
+  void positionLayoutsInMainLayout() {
+    //Todo Replace View with Layout
+    contentGridLayout.addComponent(projectInformationView, 0, 0, 0, 1)
+    contentGridLayout.addComponent(customerInformationLayout, 1, 1)
+    contentGridLayout.addComponent(projectManagerLayout, 1, 2)
+    contentGridLayout.addComponent(pricingLayout, 1, 3)
+    //ToDo extract relevant view from layout
+    contentGridLayout.addComponent(selectItemsView, 0, 4, 1, 4)
+    contentGridLayout.addComponent(cancelSubmissionButtonBarLayout, 1, 5)
+  }
 
-    /**
-     * Initializes the view with the ProjectInformationView, which is the first component to be shown
-     */
-    private void initLayout() {
-        final Label label = new Label("Update Offer")
-
-        label.addStyleName(ValoTheme.LABEL_HUGE)
-        this.addComponent(label)
-
-        navigationView = new ButtonNavigationView()
-                .addNavigationItem("1. Project Information")
-                .addNavigationItem("2. Select Customer")
-                .addNavigationItem("3. Assign Project Manager")
-                .addNavigationItem("4. Add Product Items")
-                .addNavigationItem("5. Offer Overview")
-
-        navigationView.showNextStep()
-        this.addComponent(navigationView)
-        this.addComponents(
-                projectInformationView,
-                customerSelectionView,
-                createCustomerView,
-                updatePersonView,
-                projectManagerSelectionView,
-                selectItemsView,
-                overviewView
-        )
-        this.setSizeFull()
-        this.setMargin(false)
-        this.setSpacing(false)
-
-    }
-
-    /**
-     * Registers all listeners for the buttons that enable switching between the different subviews of CreateOfferView and saving the offer
-     */
-    private void registerListeners() {
-
-        this.projectInformationView.next.addClickListener({ event ->
-            viewHistory.loadNewView(customerSelectionView)
-            navigationView.showNextStep()
-        })
-        this.customerSelectionView.next.addClickListener({
-            viewHistory.loadNewView(projectManagerSelectionView)
-            navigationView.showNextStep()
-        })
-        this.customerSelectionView.previous.addClickListener({
-            viewHistory.loadNewView(projectInformationView)
-            navigationView.showPreviousStep()
-        })
-        this.createCustomerView.abortButton.addClickListener({
-            viewHistory.showPrevious()
-        })
-        this.createCustomerView.submitButton.addClickListener({
-            viewHistory.showPrevious()
-        })
-        this.customerSelectionView.createCustomerButton.addClickListener({
-            viewHistory.loadNewView(createCustomerView)
-        })
-        this.customerSelectionView.updatePerson.addClickListener({
-            viewHistory.loadNewView(updatePersonView)
-        })
-        this.updatePersonView.abortButton.addClickListener({
-            customerSelectionView.reset()
-            viewHistory.showPrevious()
-        })
-        this.updatePersonView.submitButton.addClickListener({
-            customerSelectionView.reset()
-            viewHistory.showPrevious()
-        })
-        this.createAffiliationView.addAbortListener({
-            viewHistory.showPrevious()
-        })
-        this.createAffiliationView.addSubmitListener({
-            viewHistory.showPrevious()
-        })
-        this.projectManagerSelectionView.next.addClickListener({
-            viewHistory.loadNewView(selectItemsView)
-            navigationView.showNextStep()
-        })
-        this.projectManagerSelectionView.previous.addClickListener({
-            viewHistory.loadNewView(customerSelectionView)
-            navigationView.showPreviousStep()
-        })
-        this.selectItemsView.next.addClickListener({
-            controller.calculatePriceForItems(getProductItems(viewModel.productItems),
-                    viewModel.customerAffiliation)
-            overviewView.fillPanel()
-            viewHistory.loadNewView(overviewView)
-            navigationView.showNextStep()
-        })
-        this.selectItemsView.previous.addClickListener({
-            viewHistory.loadNewView(projectManagerSelectionView)
-            navigationView.showPreviousStep()
-        })
-        this.overviewView.previous.addClickListener({
-            viewHistory.loadNewView(selectItemsView)
-            navigationView.showPreviousStep()
-        })
-        this.overviewView.save.addClickListener({
-            controller.updateOffer(
-                    viewModel.offerId,
-                    viewModel.projectTitle,
-                    viewModel.projectObjective,
-                    viewModel.customer,
-                    viewModel.projectManager,
-                    getProductItems(viewModel.productItems),
-                    viewModel.customerAffiliation,
-                    viewModel.experimentalDesign)
-        })
-        this.viewModel.addPropertyChangeListener("offerCreatedSuccessfully", {
-            resetViewContent()
-        })
-        this.viewModel.resetViewRequired.register({
-            resetViewContent()
-        })
-    }
-
-    /**
-     * Translates the ProductItemViewModel into the ProductItem DTO
-     * @param items The items of type ProductItemViewModel which are used from the view
-     * @return list of items of type ProductItem
-     */
-    private static List<ProductItem> getProductItems(List<ProductItemViewModel> items) {
-        List<ProductItem> productItems = []
-        items.each {
-            productItems.add(new ProductItem(it.quantity, it.product))
-        }
-        return productItems
-    }
-
-    private void hideViews() {
-        this.projectInformationView.setVisible(false)
-        this.customerSelectionView.setVisible(false)
-        this.createCustomerView.setVisible(false)
-        this.updatePersonView.setVisible(false)
-        this.createAffiliationView.setVisible(false)
-        this.projectManagerSelectionView.setVisible(false)
-        this.selectItemsView.setVisible(false)
-        this.overviewView.setVisible(false)
-    }
-
-    private void addStepViewsToCurrent() {
-        this.addComponents(
-                this.projectInformationView,
-                this.customerSelectionView,
-                this.createCustomerView,
-                this.updatePersonView,
-                this.createAffiliationView,
-                this.projectManagerSelectionView,
-                this.selectItemsView,
-                this.overviewView)
-    }
-
-    void resetViewContent() {
-        viewHistory.loadNewView(this.projectInformationView)
-        navigationView.rewind()
-        projectInformationView.reset()
-        customerSelectionView.reset()
-        projectManagerSelectionView.reset()
-        selectItemsView.reset()
-    }
-
-    /*
-     * Small helper class that assists us keeping track of the view components
-     * history.
-     */
-
-    private class ViewHistory {
-
-        private List<Component> history
-
-        private int currentPosition
-
-        private Component currentView
-
-        ViewHistory(Component c) {
-            history = new LinkedList<>()
-            currentPosition = 0
-            currentView = c
-            history.add(c)
-            currentView.setVisible(true)
-        }
-
-        def loadNewView(Component view) {
-            history = history.size() > 1 ? history.subList(0, currentPosition + 1) : history
-            history.add(view)
-            currentView.setVisible(false)
-            currentView = view
-            currentView.setVisible(true)
-            currentPosition++
-        }
-
-        def showNext() {
-            if (currentPosition == history.size() - 1) {
-                // the current view is the latest view in history
-            } else {
-                currentPosition++
-                currentView.setVisible(false)
-                currentView = history.get(currentPosition)
-                currentView.setVisible(true)
-            }
-        }
-
-        def showPrevious() {
-            if (currentPosition == 0) {
-                // the current view is the oldest view in history
-            } else {
-                currentPosition -= 1
-                currentView.setVisible(false)
-                currentView = history.get(currentPosition)
-                currentView.setVisible(true)
-            }
-        }
-    }
+  void resetViewContent() {
+    //ToDo Reset Content of all Layouts and Views
+  }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/PricingLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/PricingLayout.java
@@ -4,11 +4,13 @@ import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can see the pricing of the offer selected in the
+ * UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * PricingLayout will be integrated into the UpdateOfferView and will list the net price, overhead
+ * price, price after taxes and the total Price of an offer to be updated
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class PricingLayout extends HorizontalLayout {
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/PricingLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/PricingLayout.java
@@ -1,0 +1,41 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class PricingLayout extends HorizontalLayout {
+
+  Label netPrice;
+  Label overheadPrice;
+  Label taxesPrice;
+  Label totalPrice;
+
+  public PricingLayout() {
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    netPrice = new Label("Net Sum");
+    netPrice.setCaption("Net Price");
+    overheadPrice = new Label("Overhead Sum");
+    overheadPrice.setCaption("Overheads");
+    taxesPrice = new Label("Taxes Sum");
+    taxesPrice.setCaption("Taxes");
+    totalPrice = new Label("Total Sum");
+    totalPrice.setCaption("Total Costs");
+    this.addComponents(netPrice, overheadPrice, taxesPrice, totalPrice);
+  }
+
+  private void styleLayout() {
+
+  }
+
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProductItemsLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProductItemsLayout.java
@@ -1,0 +1,41 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Grid;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.VerticalLayout;
+import life.qbic.business.products.ProductItem;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class ProductItemsLayout extends VerticalLayout {
+
+  private Button updateItemButton;
+  private Button removeItemButton;
+
+  HorizontalLayout buttonBarLayout;
+  Grid<ProductItem> productItemsGrid;
+
+  public ProductItemsLayout() {
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    productItemsGrid = new Grid<ProductItem>();
+    buttonBarLayout = new HorizontalLayout();
+    updateItemButton = new Button("Update Items");
+    removeItemButton = new Button("Remove Items");
+    buttonBarLayout.addComponents(updateItemButton, removeItemButton);
+    this.addComponents(buttonBarLayout, productItemsGrid);
+  }
+
+  private void styleLayout() {
+    productItemsGrid.setWidthFull();
+  }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProductItemsLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProductItemsLayout.java
@@ -7,11 +7,14 @@ import com.vaadin.ui.VerticalLayout;
 import life.qbic.business.products.ProductItem;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can see the productItems of the offer selected in
+ * the UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * ProductItemsLayout will be integrated into the UpdateOfferView and will provide an overview of
+ * all the productItems associated with an offer. Furthermore, it will provide the ability to inline
+ * edit and delete productItems directly in the OfferUpdateView
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class ProductItemsLayout extends VerticalLayout {
 
@@ -37,5 +40,6 @@ public class ProductItemsLayout extends VerticalLayout {
 
   private void styleLayout() {
     productItemsGrid.setWidthFull();
+    this.setSizeFull();
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProjectInformationLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProjectInformationLayout.java
@@ -1,0 +1,38 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.TextArea;
+import com.vaadin.ui.TextField;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class ProjectInformationLayout extends VerticalLayout {
+
+  private TextField projectTitle;
+  private TextArea projectObjective;
+  private TextArea experimentalDesign;
+
+  public ProjectInformationLayout() {
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    projectTitle = new TextField("Project Title", "What a Project");
+    projectObjective = new TextArea("Project Objective", "What an Objective");
+    experimentalDesign = new TextArea("Experimental Design",
+        "Sometimes we design experiments but most of the time we don't");
+    this.addComponents(projectTitle, projectObjective, experimentalDesign);
+  }
+
+  private void styleLayout() {
+    projectTitle.setSizeFull();
+    projectObjective.setSizeFull();
+    experimentalDesign.setSizeFull();
+  }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProjectInformationLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/ProjectInformationLayout.java
@@ -5,11 +5,13 @@ import com.vaadin.ui.TextField;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can see the project information associated of the
+ * offer selected in the UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * ProjectInformationLayout will be integrated into the UpdateOfferView and will list the project
+ * title, project description and experimental design of an offer to be updated
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class ProjectInformationLayout extends VerticalLayout {
 
@@ -34,5 +36,6 @@ public class ProjectInformationLayout extends VerticalLayout {
     projectTitle.setSizeFull();
     projectObjective.setSizeFull();
     experimentalDesign.setSizeFull();
+    this.setSizeFull();
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectCustomerLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectCustomerLayout.java
@@ -1,16 +1,19 @@
 package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
 
+import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can see the customer information of the offer
+ * selected in the UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * SelectCustomerLayout will be integrated into the UpdateOfferView and will list the full name and
+ * the affiliation of a customer associated with the offer to be updated
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class SelectCustomerLayout extends VerticalLayout {
 
@@ -49,6 +52,7 @@ public class SelectCustomerLayout extends VerticalLayout {
   }
 
   private void styleLayout() {
+    customerHeaderLayout.setComponentAlignment(updateCustomerButton, Alignment.TOP_RIGHT);
     affiliationInformationLayout.setMargin(false);
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectCustomerLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectCustomerLayout.java
@@ -1,0 +1,54 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class SelectCustomerLayout extends VerticalLayout {
+
+  private Label customerHeader;
+  private Button updateCustomerButton;
+  private Label customerName;
+
+  private HorizontalLayout customerHeaderLayout;
+
+  private Label affiliationCategory;
+
+  private Label affiliationInstitute;
+
+  private Label affiliationOrganisation;
+
+  private VerticalLayout affiliationInformationLayout;
+
+  public SelectCustomerLayout() {
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    customerHeader = new Label("Customer:");
+    updateCustomerButton = new Button("Update");
+    customerName = new Label("Max Mustermann");
+    affiliationCategory = new Label("Internal");
+    affiliationInstitute = new Label("University Tübingen");
+    affiliationOrganisation = new Label("Quantitative Biology Center");
+    customerHeaderLayout = new HorizontalLayout();
+    customerHeaderLayout.addComponents(customerHeader, updateCustomerButton);
+    affiliationInformationLayout = new VerticalLayout();
+    affiliationInformationLayout.addComponents(affiliationCategory, affiliationInstitute,
+        affiliationOrganisation);
+    this.addComponents(customerHeaderLayout, customerName, affiliationInformationLayout);
+  }
+
+  private void styleLayout() {
+    affiliationInformationLayout.setMargin(false);
+  }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectProjectManagerLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectProjectManagerLayout.java
@@ -1,16 +1,19 @@
 package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
 
+import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
 import com.vaadin.ui.VerticalLayout;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can see the project manager information of the
+ * offer selected in the UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * SelectProjectManagerLayout will be integrated into the UpdateOfferView and will list the full
+ * name and the affiliation of a project Manager associated with the offer to be updated
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class SelectProjectManagerLayout extends VerticalLayout {
 
@@ -41,6 +44,8 @@ public class SelectProjectManagerLayout extends VerticalLayout {
 
   private void styleLayout() {
     projectManagerDetailLayout.setMargin(false);
+    projectManagerHeaderLayout.setComponentAlignment(updateProjectManagerButton,
+        Alignment.TOP_RIGHT);
   }
 
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectProjectManagerLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SelectProjectManagerLayout.java
@@ -1,0 +1,46 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.VerticalLayout;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class SelectProjectManagerLayout extends VerticalLayout {
+
+  private Label projectManagerHeader;
+  private Button updateProjectManagerButton;
+  private HorizontalLayout projectManagerHeaderLayout;
+  private Label projectManagerName;
+  private Label projectManagerOrganisation;
+
+  private VerticalLayout projectManagerDetailLayout;
+
+  public SelectProjectManagerLayout() {
+    initLayout();
+    styleLayout();
+  }
+
+  private void initLayout() {
+    projectManagerHeader = new Label("Project Manager:");
+    updateProjectManagerButton = new Button("Update");
+    projectManagerHeaderLayout = new HorizontalLayout();
+    projectManagerHeaderLayout.addComponents(projectManagerHeader, updateProjectManagerButton);
+    projectManagerName = new Label("Maxime MusterFrau");
+    projectManagerOrganisation = new Label("University Clinic Tübingen");
+    projectManagerDetailLayout = new VerticalLayout();
+    projectManagerDetailLayout.addComponents(projectManagerName, projectManagerOrganisation);
+    this.addComponents(projectManagerHeaderLayout, projectManagerDetailLayout);
+  }
+
+  private void styleLayout() {
+    projectManagerDetailLayout.setMargin(false);
+  }
+
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SubmissionButtonBarLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SubmissionButtonBarLayout.java
@@ -1,0 +1,34 @@
+package life.qbic.portal.offermanager.components.offer.update.UpdateOfferViewLayouts;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.HorizontalLayout;
+
+/**
+ * <class short description - One Line!>
+ * <p>
+ * <More detailed description - When to use, what it solves, etc.>
+ *
+ * @since <version tag>
+ */
+public class SubmissionButtonBarLayout extends HorizontalLayout {
+
+  private Button cancelOfferUpdateButton;
+  private Button saveOfferUpdateButton;
+
+
+  public SubmissionButtonBarLayout() {
+    initLayout();
+    styleLayout();
+
+  }
+
+  private void initLayout() {
+    cancelOfferUpdateButton = new Button("Cancel");
+    saveOfferUpdateButton = new Button("Save");
+    this.addComponents(cancelOfferUpdateButton, saveOfferUpdateButton);
+  }
+
+  private void styleLayout() {
+
+  }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SubmissionButtonBarLayout.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/offer/update/UpdateOfferViewLayouts/SubmissionButtonBarLayout.java
@@ -4,11 +4,13 @@ import com.vaadin.ui.Button;
 import com.vaadin.ui.HorizontalLayout;
 
 /**
- * <class short description - One Line!>
+ * This class generates a Layout in which the user can cancel or save changes made to an offer in
+ * the UpdateOfferView
  * <p>
- * <More detailed description - When to use, what it solves, etc.>
+ * SelectCustomerLayout will be integrated into the UpdateOfferView and will provide the
+ * functionality to discard or save the changes made to an offer in the UpdateOfferView
  *
- * @since <version tag>
+ * @since 1.6.0
  */
 public class SubmissionButtonBarLayout extends HorizontalLayout {
 
@@ -19,7 +21,6 @@ public class SubmissionButtonBarLayout extends HorizontalLayout {
   public SubmissionButtonBarLayout() {
     initLayout();
     styleLayout();
-
   }
 
   private void initLayout() {
@@ -29,6 +30,7 @@ public class SubmissionButtonBarLayout extends HorizontalLayout {
   }
 
   private void styleLayout() {
-
+    this.setMargin(false);
+    this.setSpacing(true);
   }
 }


### PR DESCRIPTION
Replaces the current UpdateOfferView with a GridLayout outlining the positions of the following sublayouts.
The stucture of the gridlayout can be seen here: https://miro.com/app/board/uXjVO4E_5wc=/

**This PR introduces:**

1. the gridlayout into which the sublayouts will be slotted. 
2. the content of the sublayouts as dummies without logic 

**ToDo in different PRs:** 

1. Parse offer content into the individual sublayouts
2. Implement sublayout logic with offer information, clicklisteners and validation
3. Style sublayouts once the offer content is parsed
4. Style updateofferview after sublayouts are finalized.