### PR TITLE
DM-481 Invalid Project Spaces allow hyphenated project spaces

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferManagerApp.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/OfferManagerApp.groovy
@@ -87,5 +87,4 @@ class OfferManagerApp extends QBiCPortletUI {
         }
         return layout
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 			<dependency>
 				<groupId>life.qbic</groupId>
 				<artifactId>data-model-lib</artifactId>
-				<version>2.19.1</version>
+				<version>2.20.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>


### PR DESCRIPTION
**What was changed** 
Bump DML version to newest release to allow hyphenated project spaces. 

**Additional Information**
See [#326 ](https://github.com/qbicsoftware/data-model-lib/pull/326) in data-model-lib for more information
