### PR TITLE
Conserve price information for products when added to an offer

### DIFF
--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -196,6 +196,10 @@ public class ProductItem {
    */
   protected BigDecimal calculateDataStorageDiscountRate(
       AffiliationCategory affiliationCategory) {
+    return calculateDataStorageDiscountRate(affiliationCategory, this.productCategory);
+  }
+
+  protected static BigDecimal calculateDataStorageDiscountRate(AffiliationCategory affiliationCategory, String productCategory) {
     if (productCategory.equalsIgnoreCase("data storage")
         && affiliationCategory == AffiliationCategory.INTERNAL) {
       return BigDecimal.ONE; // full discount

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -84,6 +84,7 @@ public class ProductItem {
     this.offer = requireNonNull(offer, "Offer must not be null");
     this.product = requireNonNull(product, "Product must not be null");
     this.quantity = requireNonNull(quantity, "Quantity must not be null");
+    // Ensure immutability of product information (including prices!)
     readProductValues(product);
     this.product = product;
     refreshProductItem();

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -82,6 +82,7 @@ public class ProductItem {
 
   public ProductItem(OfferV2 offer, Product product, Double quantity) {
     this.offer = requireNonNull(offer, "Offer must not be null");
+    this.product = requireNonNull(product, "Product must not be null");
     this.quantity = requireNonNull(quantity, "Quantity must not be null");
     copy(product);
     this.product = product;

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -156,7 +156,7 @@ public class ProductItem {
     BigDecimal quantityDiscountRate =
         calculateQuantityDiscountRate(quantity, productCategory);
     BigDecimal storageDiscountRate =
-        calculateDataStorageDiscountRate(affiliationCategory, productCategory);
+        calculateDataStorageDiscountRate(affiliationCategory);
     return quantityDiscountRate.max(storageDiscountRate);
   }
 
@@ -179,10 +179,10 @@ public class ProductItem {
    */
   protected BigDecimal determineUnitPrice(AffiliationCategory affiliationCategory) {
     if (affiliationCategory == AffiliationCategory.INTERNAL) {
-      return BigDecimal.valueOf(this.getInternalUnitPrice()).setScale(2,
+      return BigDecimal.valueOf(this.internalUnitPrice).setScale(2,
           RoundingMode.HALF_UP);
     }
-    return BigDecimal.valueOf(this.getExternalUnitPrice())
+    return BigDecimal.valueOf(this.externalUnitPrice)
         .setScale(2, RoundingMode.HALF_UP);
   }
 
@@ -192,11 +192,10 @@ public class ProductItem {
    * on data storage products.
    *
    * @param affiliationCategory the considered affiliation category for discount determination
-   * @param productCategory     the considered product category for discount determination
    * @return the discount rate for the provided product. In range [0,1]
    */
-  protected static BigDecimal calculateDataStorageDiscountRate(
-      AffiliationCategory affiliationCategory, String productCategory) {
+  protected BigDecimal calculateDataStorageDiscountRate(
+      AffiliationCategory affiliationCategory) {
     if (productCategory.equalsIgnoreCase("data storage")
         && affiliationCategory == AffiliationCategory.INTERNAL) {
       return BigDecimal.ONE; // full discount

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -110,6 +110,15 @@ public class ProductItem {
     this.serviceProvider = product.getServiceProvider();
   }
 
+  /**
+   * Helper method for the transition to make product values immutable,
+   * once they have been added to an offer.
+   *
+   * The copy of values will only happen once, if the product reference field
+   * is null, which means the copy has not been done yet.
+   *
+   * @since 1.6.0
+   */
   @PostLoad
   private void triggerProductCopy() {
     if (Objects.isNull(this.productReference)) {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -177,7 +177,7 @@ public class ProductItem {
    * @param affiliationCategory internal, external or external academic
    * @return the determined base price
    */
-  protected BigDecimal determineUnitPrice(AffiliationCategory affiliationCategory) {
+  private BigDecimal determineUnitPrice(AffiliationCategory affiliationCategory) {
     if (affiliationCategory == AffiliationCategory.INTERNAL) {
       return BigDecimal.valueOf(this.internalUnitPrice).setScale(2,
           RoundingMode.HALF_UP);
@@ -194,7 +194,7 @@ public class ProductItem {
    * @param affiliationCategory the considered affiliation category for discount determination
    * @return the discount rate for the provided product. In range [0,1]
    */
-  protected BigDecimal calculateDataStorageDiscountRate(
+  private BigDecimal calculateDataStorageDiscountRate(
       AffiliationCategory affiliationCategory) {
     return calculateDataStorageDiscountRate(affiliationCategory, this.productCategory);
   }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/products/ProductItem.java
@@ -84,12 +84,21 @@ public class ProductItem {
     this.offer = requireNonNull(offer, "Offer must not be null");
     this.product = requireNonNull(product, "Product must not be null");
     this.quantity = requireNonNull(quantity, "Quantity must not be null");
-    copy(product);
+    readProductValues(product);
     this.product = product;
     refreshProductItem();
   }
 
-  private void copy(Product product) {
+  /**
+   * Reads all product values and saves them in the {@link ProductItem} class.
+   *
+   * This ensures immutability for prices and other product related properties and
+   * conserves the product state at the time-point of addition to the offer.
+   *
+   * @param product the product to read
+   * @since 1.6.0
+   */
+  private void readProductValues(Product product) {
     this.productCategory = product.getCategory();
     this.description = product.getDescription();
     this.productName = product.getProductName();
@@ -103,7 +112,7 @@ public class ProductItem {
   @PostLoad
   private void triggerProductCopy() {
     if (Objects.isNull(this.productReference)) {
-      copy(product);
+      readProductValues(product);
     }
   }
 


### PR DESCRIPTION
Currently, price updates for service products can only be done in a safe way when the target products get updated (archiving and creating a new one). 

With this approach, new service product ids are created, which is confusing for simple price updates: its still the same product we offer.

With this refactor, we make value object out of the product entities when added to an offer and therefore conserve the information of the product at the timepoint of the addition.