### PR TITLE
Allows archiving of affiliations 

### DIFF
--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/DependencyManager.groovy
@@ -5,6 +5,9 @@ import life.qbic.business.offers.create.CreateOffer
 import life.qbic.business.offers.create.CreateOfferDataSource
 import life.qbic.business.offers.fetch.FetchOffer
 import life.qbic.business.offers.fetch.FetchOfferDataSource
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliation
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliationDataSource
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliationOutput
 import life.qbic.business.persons.affiliation.create.CreateAffiliation
 import life.qbic.business.persons.affiliation.create.CreateAffiliationDataSource
 import life.qbic.business.persons.affiliation.list.ListAffiliationsDataSource
@@ -38,6 +41,8 @@ import life.qbic.portal.offermanager.components.AppViewModel
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationController
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationPresenter
 import life.qbic.portal.offermanager.components.affiliation.create.CreateAffiliationView
+import life.qbic.portal.offermanager.components.affiliation.search.ArchiveAffiliationController
+import life.qbic.portal.offermanager.components.affiliation.search.ArchiveAffiliationPresenter
 import life.qbic.portal.offermanager.components.affiliation.search.SearchAffiliationView
 import life.qbic.portal.offermanager.components.affiliation.search.SearchAffiliationViewModel
 import life.qbic.portal.offermanager.components.affiliation.update.UpdateAffiliationController
@@ -142,6 +147,7 @@ class DependencyManager {
     private ListAffiliationsDataSource listAffiliationsDataSource
     private UpdateAffiliationDataSource updateAffiliationDataSource
     private SearchPersonDataSource searchPersonDataSource
+    private ArchiveAffiliationDataSource archiveAffiliationDataSource
     // Implemented by life.qbic.portal.offermanager.dataresources.products.ProductsDbConnector
     private ArchiveProductDataSource archiveProductDataSource
     private CreateProductDataSource createProductDataSource
@@ -200,6 +206,7 @@ class DependencyManager {
             createAffiliationDataSource = affiliationDbConnector
             updateAffiliationDataSource = affiliationDbConnector
             listAffiliationsDataSource = affiliationDbConnector
+            archiveAffiliationDataSource = affiliationDbConnector
 
             ProductsDbConnector productsDbConnector = new ProductsDbConnector(DatabaseSession.getInstance())
             archiveProductDataSource = productsDbConnector
@@ -333,9 +340,11 @@ class DependencyManager {
     private SearchAffiliationView createSearchAffiliationView() {
         ResourcesService<Affiliation> affiliationResourcesService = this.affiliationService
         SearchAffiliationViewModel searchAffiliationViewModel = new SearchAffiliationViewModel(affiliationResourcesService)
-
+        ArchiveAffiliationOutput archiveAffiliationOutput = new ArchiveAffiliationPresenter(affiliationResourcesService, this.viewModel)
+        ArchiveAffiliation archiveAffiliation = new ArchiveAffiliation(archiveAffiliationOutput, archiveAffiliationDataSource)
         UpdateAffiliationView updateAffiliationView = createUpdateAffiliationView()
-        SearchAffiliationView searchAffiliationView = new SearchAffiliationView(searchAffiliationViewModel, updateAffiliationView)
+        ArchiveAffiliationController controller = new ArchiveAffiliationController(archiveAffiliation)
+        SearchAffiliationView searchAffiliationView = new SearchAffiliationView(searchAffiliationViewModel, updateAffiliationView, controller)
         return searchAffiliationView
     }
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/ArchiveAffiliationController.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/ArchiveAffiliationController.java
@@ -1,0 +1,24 @@
+package life.qbic.portal.offermanager.components.affiliation.search;
+
+import java.util.Objects;
+import life.qbic.business.RefactorConverter;
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliationInput;
+import life.qbic.datamodel.dtos.business.Affiliation;
+
+public class ArchiveAffiliationController {
+
+  private final ArchiveAffiliationInput archiveAffiliationInput;
+
+  public ArchiveAffiliationController(ArchiveAffiliationInput archiveAffiliationInput) {
+    this.archiveAffiliationInput = Objects.requireNonNull(archiveAffiliationInput);
+  }
+
+  public void archive(Affiliation affiliation) {
+    life.qbic.business.persons.affiliation.Affiliation convertedAffiliation = RefactorConverter.toAffiliation(affiliation);
+    archiveAffiliationInput.archive(convertedAffiliation);
+  }
+
+
+
+
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/ArchiveAffiliationPresenter.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/ArchiveAffiliationPresenter.java
@@ -1,0 +1,34 @@
+package life.qbic.portal.offermanager.components.affiliation.search;
+
+import java.util.Objects;
+import life.qbic.business.RefactorConverter;
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliationOutput;
+import life.qbic.datamodel.dtos.business.Affiliation;
+import life.qbic.portal.offermanager.components.AppViewModel;
+import life.qbic.portal.offermanager.dataresources.ResourcesService;
+
+public class ArchiveAffiliationPresenter implements ArchiveAffiliationOutput {
+
+  private final ResourcesService<Affiliation> affiliationResourcesService;
+
+  private final AppViewModel sharedViewModel;
+
+  public ArchiveAffiliationPresenter(ResourcesService<Affiliation> affiliationResourcesService,
+      AppViewModel sharedViewModel) {
+    this.affiliationResourcesService = Objects.requireNonNull(affiliationResourcesService);
+    this.sharedViewModel = Objects.requireNonNull(sharedViewModel);
+  }
+
+
+  @Override
+  public void failNotification(String notification) {
+    sharedViewModel.getFailureNotifications().add(notification);
+  }
+
+  @Override
+  public void archivedAffiliation(life.qbic.business.persons.affiliation.Affiliation affiliation) {
+    affiliationResourcesService.reloadResources();
+    affiliationResourcesService.removeFromResource(RefactorConverter.toAffiliationDto(affiliation));
+    sharedViewModel.getSuccessNotifications().add("Archived affiliation successfully");
+  }
+}

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationView.groovy
@@ -34,6 +34,10 @@ class SearchAffiliationView extends FormLayout implements Observer {
 
     private ArchiveAffiliationController controller
 
+    private Button updateAffiliationButton
+
+    private Button archiveAffiliationButton
+
     SearchAffiliationView(SearchAffiliationViewModel viewModel, UpdateAffiliationView updateAffiliationView,
                           ArchiveAffiliationController affiliationController) {
         this.viewModel = viewModel
@@ -72,10 +76,10 @@ class SearchAffiliationView extends FormLayout implements Observer {
 
     private HorizontalLayout generateButtonLayout() {
         HorizontalLayout buttonLayout = new HorizontalLayout()
-        def updateButton = generateUpdateButton()
-        def archiveButton = generateArchivingButton()
-        buttonLayout.addComponent(updateButton)
-        buttonLayout.addComponent(archiveButton)
+        this.updateAffiliationButton = generateUpdateButton()
+        this.archiveAffiliationButton = generateArchivingButton()
+        buttonLayout.addComponent(updateAffiliationButton)
+        buttonLayout.addComponent(archiveAffiliationButton)
 
         return buttonLayout
     }
@@ -272,6 +276,12 @@ class SearchAffiliationView extends FormLayout implements Observer {
         // We want to refresh the grid, so that cached items are removed and the content
         // reflects the current content of available (active) affiliations
         this.affiliationGrid.getDataProvider().refreshAll()
+        disableActionButtons()
+    }
+
+    private void disableActionButtons() {
+        this.archiveAffiliationButton.setEnabled(false)
+        this.updateAffiliationButton.setEnabled(false)
     }
 
 

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationView.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationView.groovy
@@ -38,7 +38,7 @@ class SearchAffiliationView extends FormLayout implements Observer {
                           ArchiveAffiliationController affiliationController) {
         this.viewModel = viewModel
         this.updateAffiliationView = updateAffiliationView
-        this.controller = Objects.requireNonNull(affiliationController)
+        this.controller = Objects.requireNonNull(affiliationController, "affiliaiton controller must not be null")
 
         initLayout()
         generateAffiliationGrid()

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationViewModel.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/components/affiliation/search/SearchAffiliationViewModel.groovy
@@ -11,7 +11,7 @@ import life.qbic.portal.offermanager.dataresources.ResourcesService
  *
  * @since 1.0.0
  */
-class SearchAffiliationViewModel {
+class SearchAffiliationViewModel extends Observable {
 
     /**
      * A list of available affiliations. All items are of class {@link Affiliation}
@@ -41,6 +41,9 @@ class SearchAffiliationViewModel {
         selectedAffiliation = Optional.empty()
 
         affiliations.addAll(affiliationResourcesService.iterator())
+
+        setChanged()
+        notifyObservers()
     }
 
     /**
@@ -53,4 +56,6 @@ class SearchAffiliationViewModel {
             resetAffiliations()
         })
     }
+
+
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/AffiliationDbConnector.java
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/AffiliationDbConnector.java
@@ -8,6 +8,7 @@ import life.qbic.business.exceptions.DatabaseQueryException;
 import life.qbic.business.persons.affiliation.Affiliation;
 import life.qbic.business.persons.affiliation.AffiliationExistsException;
 import life.qbic.business.persons.affiliation.AffiliationNotFoundException;
+import life.qbic.business.persons.affiliation.archive.ArchiveAffiliationDataSource;
 import life.qbic.business.persons.affiliation.create.CreateAffiliationDataSource;
 import life.qbic.business.persons.affiliation.list.ListAffiliationsDataSource;
 import life.qbic.business.persons.affiliation.update.UpdateAffiliationDataSource;
@@ -19,7 +20,7 @@ import org.hibernate.query.Query;
 
 
 public class AffiliationDbConnector implements CreateAffiliationDataSource,
-    ListAffiliationsDataSource, UpdateAffiliationDataSource {
+    ListAffiliationsDataSource, UpdateAffiliationDataSource, ArchiveAffiliationDataSource {
 
   private final SessionProvider sessionProvider;
 
@@ -97,5 +98,17 @@ public class AffiliationDbConnector implements CreateAffiliationDataSource,
     session.clear();
     session.getTransaction().commit();
     return isInSession;
+  }
+
+  @Override
+  public void archiveAffiliation(Affiliation affiliation) throws DatabaseQueryException {
+    try(Session session = sessionProvider.getCurrentSession()) {
+      session.beginTransaction();
+      session.merge(affiliation);
+      session.getTransaction().commit();
+    } catch (HibernateException e) {
+      log.error(e);
+      throw new DatabaseQueryException("Archiving failed");
+    }
   }
 }

--- a/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/AffiliationResourcesService.groovy
+++ b/offer-manager-app/src/main/groovy/life/qbic/portal/offermanager/dataresources/persons/AffiliationResourcesService.groovy
@@ -7,6 +7,8 @@ import life.qbic.portal.offermanager.communication.EventEmitter
 import life.qbic.portal.offermanager.communication.Subscription
 import life.qbic.portal.offermanager.dataresources.ResourcesService
 
+import java.util.stream.Collectors
+
 /**
  * Customer service that holds resources about available affiliations
  *
@@ -32,7 +34,7 @@ class AffiliationResourcesService implements ResourcesService<Affiliation> {
         this.eventEmitter = new EventEmitter<>()
     }
 
-    private static Collection fetchAllAffiliations(ListAffiliationsDataSource listAffiliationsDataSource) {
+    private static List<Affiliation> fetchAllAffiliations(ListAffiliationsDataSource listAffiliationsDataSource) {
         RefactorConverter refactorConverter = new RefactorConverter()
         return listAffiliationsDataSource.listAllAffiliations().stream()
                 .map(refactorConverter::toAffiliationDto)
@@ -73,6 +75,8 @@ class AffiliationResourcesService implements ResourcesService<Affiliation> {
 
     @Override
     Iterator<Affiliation> iterator() {
-        return new ArrayList(availableAffiliations).iterator()
+        return new ArrayList<>(availableAffiliations).stream()
+                .filter(affiliation -> affiliation.isActive())
+                .collect(Collectors.toList()).iterator()
     }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/RefactorConverter.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/RefactorConverter.java
@@ -264,6 +264,7 @@ public class RefactorConverter {
     affiliationDtoBuilder.setId(affiliation.getId());
     affiliationDtoBuilder.category(toAffiliationCategoryDto(affiliation.getCategory()));
     affiliationDtoBuilder.country(affiliation.getCountry());
+    affiliationDtoBuilder.setActive(affiliation.isActive());
     if (affiliation.getAddressAddition() != null && !affiliation.getAddressAddition().isEmpty()) {
       affiliationDtoBuilder.setAddressAddition(affiliation.getAddressAddition());
     }
@@ -282,6 +283,9 @@ public class RefactorConverter {
         affiliationDto.getCountry(),
         affiliationCategory);
     affiliation.setId(affiliationDto.getId());
+    if (!affiliationDto.isActive()) {
+      affiliation.archive();
+    }
     return affiliation;
   }
 

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/Person.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/Person.groovy
@@ -4,6 +4,7 @@ import groovy.transform.ToString
 import life.qbic.business.persons.affiliation.Affiliation
 
 import javax.persistence.*
+import java.util.stream.Collectors
 
 /**
  * <b><class short description - 1 Line!></b>
@@ -53,7 +54,11 @@ class Person {
 
     @PostLoad
     protected void onPostLoad() {
-        this.getAffiliations()
+        loadAffiliations()
+    }
+
+    private List<Affiliation> loadAffiliations(){
+        return this.affiliations
     }
 
     static create(String userId, String firstName, String lastName, String title, String email, List<Affiliation> affiliations) {
@@ -135,8 +140,15 @@ class Person {
         this.email = email
     }
 
+    /**
+     * Returns active affiliations of a person
+     * @return
+     * @since 1.6.0
+     */
     List<Affiliation> getAffiliations() {
-        return affiliations
+        List<Affiliation> activeAffiliations = affiliations.stream()
+                .filter(affiliation -> affiliation.isActive()).collect(Collectors.toList())
+        return activeAffiliations
     }
 
     void setAffiliations(List<Affiliation> affiliations) {

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
@@ -39,8 +39,8 @@ class Affiliation {
     @Column(name = "country")
     String country
 
-    @Column(name = "active")
-    Integer active
+    @Column(name = "active", columnDefinition="TINYINT(1)")
+    boolean active
 
     @Column(name = "category")
     @Convert(converter = AffiliationCategoryConverter.class)

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
@@ -39,7 +39,7 @@ class Affiliation {
     @Column(name = "country")
     String country
 
-    @Column(name = "active", columnDefinition="TINYINT(1)")
+    @Column(name = "active", columnDefinition = "TINYINT(1)")
     boolean active
 
     @Column(name = "category")
@@ -54,7 +54,7 @@ class Affiliation {
         this.city = city
         this.country = country
         this.category = category
-        this.active = 1
+        this.active = true // default setting is the affiliation to be active
     }
 
     Affiliation() {
@@ -125,22 +125,19 @@ class Affiliation {
         this.category = category
     }
 
-    private setActive(int value) {
-        if (value != 0 && value != 1) {
-            throw new IllegalArgumentException("Value must be 0 (inactive) or 1 (active)")
-        }
+    private setActive(boolean value) {
         this.active = value
     }
 
-    private Integer getActive() {
+    private boolean getActive() {
         return active
     }
 
     Boolean isActive() {
-        return active == 1 ? Boolean.TRUE : Boolean.FALSE
+        return active
     }
 
     void archive() {
-        this.active = 0
+        this.active = false
     }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/Affiliation.groovy
@@ -39,6 +39,9 @@ class Affiliation {
     @Column(name = "country")
     String country
 
+    @Column(name = "active")
+    Integer active
+
     @Column(name = "category")
     @Convert(converter = AffiliationCategoryConverter.class)
     AffiliationCategory category
@@ -51,6 +54,7 @@ class Affiliation {
         this.city = city
         this.country = country
         this.category = category
+        this.active = 1
     }
 
     Affiliation() {
@@ -119,5 +123,24 @@ class Affiliation {
 
     void setCategory(AffiliationCategory category) {
         this.category = category
+    }
+
+    private setActive(int value) {
+        if (value != 0 && value != 1) {
+            throw new IllegalArgumentException("Value must be 0 (inactive) or 1 (active)")
+        }
+        this.active = value
+    }
+
+    private Integer getActive() {
+        return active
+    }
+
+    Boolean isActive() {
+        return active == 1 ? Boolean.TRUE : Boolean.FALSE
+    }
+
+    void archive() {
+        this.active = 0
     }
 }

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliation.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliation.java
@@ -1,0 +1,37 @@
+package life.qbic.business.persons.affiliation.archive;
+
+import java.util.Objects;
+import life.qbic.business.logging.Logger;
+import life.qbic.business.logging.Logging;
+import life.qbic.business.persons.affiliation.Affiliation;
+
+public class ArchiveAffiliation implements ArchiveAffiliationInput {
+
+  private final ArchiveAffiliationOutput archiveAffiliationOutput;
+  private final ArchiveAffiliationDataSource archiveAffiliationDataSource;
+
+  private final Logging log = Logger.getLogger(this.getClass());
+
+  public ArchiveAffiliation(ArchiveAffiliationOutput archiveAffiliationOutput, ArchiveAffiliationDataSource archiveAffiliationDataSource) {
+    this.archiveAffiliationOutput = Objects.requireNonNull(archiveAffiliationOutput);
+    this.archiveAffiliationDataSource = Objects.requireNonNull(
+        archiveAffiliationDataSource);
+  }
+
+  @Override
+  public void archive(Affiliation affiliation) {
+    if (Objects.isNull(affiliation)) {
+      log.error("Affiliation must not be null");
+      archiveAffiliationOutput.failNotification("Archiving failed");
+      return;
+    }
+    try {
+      affiliation.archive();
+      archiveAffiliationDataSource.archiveAffiliation(affiliation);
+      archiveAffiliationOutput.archivedAffiliation(affiliation);
+    } catch (Exception e) {
+      log.error("Archiving failed", e);
+      archiveAffiliationOutput.failNotification("Archiving failed");
+    }
+  }
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationDataSource.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationDataSource.java
@@ -1,0 +1,9 @@
+package life.qbic.business.persons.affiliation.archive;
+
+import life.qbic.business.persons.affiliation.Affiliation;
+
+public interface ArchiveAffiliationDataSource {
+
+  void archiveAffiliation(Affiliation affiliation);
+
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationInput.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationInput.java
@@ -1,0 +1,9 @@
+package life.qbic.business.persons.affiliation.archive;
+
+import life.qbic.business.persons.affiliation.Affiliation;
+
+public interface ArchiveAffiliationInput {
+
+  void archive(Affiliation affiliation);
+
+}

--- a/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationOutput.java
+++ b/offer-manager-domain/src/main/groovy/life/qbic/business/persons/affiliation/archive/ArchiveAffiliationOutput.java
@@ -1,0 +1,11 @@
+package life.qbic.business.persons.affiliation.archive;
+
+import life.qbic.business.UseCaseFailure;
+import life.qbic.business.persons.affiliation.Affiliation;
+
+
+public interface ArchiveAffiliationOutput extends UseCaseFailure {
+
+  void archivedAffiliation(Affiliation affiliation);
+
+}


### PR DESCRIPTION
Affiliations can now be archived from the Affiliations > Search context.

Existing references in offers are not affected, only future selection of archived affiliations wont be possible any more.