### PR TITLE
Update data-model-lib version to 2.29.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 			<dependency>
 				<groupId>life.qbic</groupId>
 				<artifactId>data-model-lib</artifactId>
-				<version>2.26.0</version>
+				<version>2.29.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.vaadin</groupId>


### PR DESCRIPTION
The version of the data-model-lib dependency has been updated from 2.26.0 to 2.29.1.